### PR TITLE
backend: Improve handling of connection to dcrd

### DIFF
--- a/backend/common_test.go
+++ b/backend/common_test.go
@@ -404,4 +404,19 @@ func (mc *mockChain) Version(ctx context.Context) (map[string]chainjson.VersionR
 func (mc *mockChain) Connect(ctx context.Context, retry bool) error {
 	return nil
 }
+
+// newTestServer returns a Server instance that is forced into the connected
+// state, so that functions that depend on having a connected chain work.
+func newTestServer(t *testing.T, cfg *ServerConfig) *Server {
+	t.Helper()
+
+	svr, err := NewServer(context.Background(), cfg)
+	require.NoError(t, err)
+
+	// Force the server to be connected.
+	svr.mtx.Lock()
+	svr.dcrdActiveErr = nil
+	svr.mtx.Unlock()
+
+	return svr
 }

--- a/backend/common_test.go
+++ b/backend/common_test.go
@@ -414,7 +414,7 @@ func newTestServer(t *testing.T, cfg *ServerConfig) *Server {
 	t.Helper()
 
 	ctxt, cancel := context.WithCancel(context.Background())
-	svr, err := NewServer(ctxt, cfg)
+	svr, err := NewServer(cfg)
 	require.NoError(t, err)
 	t.Cleanup(cancel)
 

--- a/backend/server.go
+++ b/backend/server.go
@@ -127,7 +127,7 @@ type Server struct {
 }
 
 // NewServer creates a new server instance.
-func NewServer(ctx context.Context, cfg *ServerConfig) (*Server, error) {
+func NewServer(cfg *ServerConfig) (*Server, error) {
 	network := &rtypes.NetworkIdentifier{
 		Blockchain: "decred",
 		Network:    cfg.ChainParams.Name,

--- a/backend/server_test.go
+++ b/backend/server_test.go
@@ -93,7 +93,9 @@ func TestServerProcessesNotifications(t *testing.T) {
 	}
 	ctxt, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	svr := newTestServer(t, cfg)
+	svr, err := NewServer(ctxt, cfg)
+	require.NoError(t, err)
+	t.Cleanup(cancel)
 
 	// Helpful functions to drive the server forward.
 	tipHeader := func() []byte {
@@ -230,7 +232,8 @@ func TestRunsAllDBTypes(t *testing.T) {
 				c:           c,
 			}
 			ctxt, cancel := context.WithCancel(context.Background())
-			svr := newTestServer(t, cfg)
+			svr, err := NewServer(ctxt, cfg)
+			require.NoError(t, err)
 
 			// runDone will receive the result of the Run() call.
 			runDone := make(chan error)
@@ -265,4 +268,101 @@ func TestRunsAllDBTypes(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestRunAPI ensures Run() can't be called with an empty context or twice for
+// the same server.
+func TestRunAPI(t *testing.T) {
+	params := chaincfg.SimNetParams()
+	c := newMockChain(t, params)
+
+	// Helper to call Run() and assert it doesn't immediately return with
+	// an error. Returns a chan that will get written to once Run() ends.
+	runNoErr := func(t *testing.T, svr *Server, ctx context.Context) chan error {
+		c := make(chan error)
+		go func() {
+			c <- svr.Run(ctx)
+		}()
+
+		select {
+		case err := <-c:
+			t.Fatalf("unexpected Run() error: %v", err)
+		case <-time.After(100 * time.Millisecond):
+		}
+		return c
+	}
+
+	// Helper to call Run() on a goroutine and assert it returns
+	// immediately with an error.
+	runWithErr := func(t *testing.T, svr *Server, ctx context.Context) error {
+		c := make(chan error)
+		go func() {
+			c <- svr.Run(ctx)
+		}()
+		var err error
+		select {
+		case err = <-c:
+		case <-time.After(100 * time.Millisecond):
+			t.Fatalf("unexpected timeout while waiting for Run() to error")
+		}
+		return err
+	}
+
+	cfg := &ServerConfig{
+		ChainParams: params,
+		DBType:      dbTypePreconfigured,
+		c:           c,
+	}
+
+	t.Run("passing nil context errors", func(t *testing.T) {
+		svr, err := NewServer(context.Background(), cfg)
+		require.NoError(t, err)
+		err = runWithErr(t, svr, nil)
+		if err == nil {
+			t.Fatalf("unexpected nil error when calling Run(nil)")
+		}
+	})
+
+	t.Run("passing done context errors", func(t *testing.T) {
+		svr, err := NewServer(context.Background(), cfg)
+		require.NoError(t, err)
+		ctxt, cancel := context.WithCancel(context.Background())
+		cancel()
+		err = runWithErr(t, svr, ctxt)
+		wantErr := context.Canceled
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("unexpected error. want=%v got=%v", wantErr, err)
+		}
+	})
+
+	t.Run("call run twice errors", func(t *testing.T) {
+		ctxt, cancel := context.WithCancel(context.Background())
+		svr, err := NewServer(context.Background(), cfg)
+		require.NoError(t, err)
+
+		// First Run() call should work.
+		errChan := runNoErr(t, svr, ctxt)
+
+		// Second Run() call while the server is running should fail.
+		wantErr := errRunCalledTwice
+		err = svr.Run(ctxt)
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("unexpected error. want=%v, got=%v", wantErr, err)
+		}
+
+		// Second Run() call after the original context is closed
+		// should fail.
+		cancel()
+		<-errChan
+		err = runWithErr(t, svr, ctxt)
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("unexpected error. want=%v, got=%v", wantErr, err)
+		}
+
+		// Second Run() call with a different context should fail.
+		err = svr.Run(context.Background())
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("unexpected error. want=%v, got=%v", wantErr, err)
+		}
+	})
 }

--- a/backend/server_test.go
+++ b/backend/server_test.go
@@ -32,7 +32,7 @@ func TestOnDcrdConnected(t *testing.T) {
 		DBType:      dbTypePreconfigured,
 		c:           c,
 	}
-	svr, err := NewServer(context.Background(), cfg)
+	svr, err := NewServer(cfg)
 	require.NoError(t, err)
 
 	// Server starts out disconnected.
@@ -93,7 +93,7 @@ func TestServerProcessesNotifications(t *testing.T) {
 	}
 	ctxt, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	svr, err := NewServer(ctxt, cfg)
+	svr, err := NewServer(cfg)
 	require.NoError(t, err)
 	t.Cleanup(cancel)
 
@@ -199,7 +199,7 @@ func TestNewErrorsUnknownDBType(t *testing.T) {
 		DBType:      DBType("*booo"),
 		c:           c,
 	}
-	_, err := NewServer(context.Background(), cfg)
+	_, err := NewServer(cfg)
 	wantErr := errUnknownDBType
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("unexpected error. want=%v, got=%v", wantErr, err)
@@ -232,7 +232,7 @@ func TestRunsAllDBTypes(t *testing.T) {
 				c:           c,
 			}
 			ctxt, cancel := context.WithCancel(context.Background())
-			svr, err := NewServer(ctxt, cfg)
+			svr, err := NewServer(cfg)
 			require.NoError(t, err)
 
 			// runDone will receive the result of the Run() call.
@@ -315,7 +315,7 @@ func TestRunAPI(t *testing.T) {
 	}
 
 	t.Run("passing nil context errors", func(t *testing.T) {
-		svr, err := NewServer(context.Background(), cfg)
+		svr, err := NewServer(cfg)
 		require.NoError(t, err)
 		err = runWithErr(t, svr, nil)
 		if err == nil {
@@ -324,7 +324,7 @@ func TestRunAPI(t *testing.T) {
 	})
 
 	t.Run("passing done context errors", func(t *testing.T) {
-		svr, err := NewServer(context.Background(), cfg)
+		svr, err := NewServer(cfg)
 		require.NoError(t, err)
 		ctxt, cancel := context.WithCancel(context.Background())
 		cancel()
@@ -337,7 +337,7 @@ func TestRunAPI(t *testing.T) {
 
 	t.Run("call run twice errors", func(t *testing.T) {
 		ctxt, cancel := context.WithCancel(context.Background())
-		svr, err := NewServer(context.Background(), cfg)
+		svr, err := NewServer(cfg)
 		require.NoError(t, err)
 
 		// First Run() call should work.

--- a/backend/svc_account.go
+++ b/backend/svc_account.go
@@ -163,6 +163,11 @@ func (s *Server) preProcessAccounts(ctx context.Context) error {
 		return err
 	}
 
+	// Ensure we're connected to a suitable dcrd instance.
+	if err := s.isDcrdActive(); err != nil {
+		return err
+	}
+
 	// Verify if the last processed block matches the block in the mainchain
 	// at startHeight. If it doesn't, we'll have to roll back due to a reorg
 	// that happened while we were offline.

--- a/backend/svc_account_test.go
+++ b/backend/svc_account_test.go
@@ -206,14 +206,10 @@ func testPreprocessesAccounts(t *testing.T, db backenddb.DB) {
 		c:           c,
 		db:          db,
 	}
-
-	ctxt, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	svr, err := NewServer(ctxt, cfg)
-	require.NoError(t, err)
+	svr := newTestServer(t, cfg)
 
 	// Preprocess accounts.
-	err = svr.preProcessAccounts(testCtx(t))
+	err := svr.preProcessAccounts(testCtx(t))
 	require.NoError(t, err)
 
 	// Verify the historical balance at each block.
@@ -262,13 +258,10 @@ func testPreprocessesGenesis(t *testing.T, db backenddb.DB) {
 		c:           c,
 		db:          db,
 	}
-	ctxt, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	svr, err := NewServer(ctxt, cfg)
-	require.NoError(t, err)
+	svr := newTestServer(t, cfg)
 
 	// Preprocess.
-	err = svr.preProcessAccounts(testCtx(t))
+	err := svr.preProcessAccounts(testCtx(t))
 	require.NoError(t, err)
 }
 
@@ -300,17 +293,14 @@ func testPreprocessesAfterRestart(t *testing.T, db backenddb.DB) {
 		c:           c,
 		db:          db,
 	}
-	ctxt, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	svr, err := NewServer(ctxt, cfg)
-	require.NoError(t, err)
+	svr := newTestServer(t, cfg)
 
 	// Generate a chain that funds an account.
 	c.extendTip(toAddr(11, 1))
 	c.extendTip(fromAddr(5, 1))
 
 	// Preprocess.
-	err = svr.preProcessAccounts(testCtx(t))
+	err := svr.preProcessAccounts(testCtx(t))
 	require.NoError(t, err)
 
 	// Account balance should be correct.
@@ -415,10 +405,7 @@ func testReorgDuringPreprocess(t *testing.T, db backenddb.DB) {
 		c:           c,
 		db:          db,
 	}
-	ctxt, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	svr, err := NewServer(ctxt, cfg)
-	require.NoError(t, err)
+	svr := newTestServer(t, cfg)
 
 	// Override concurrency to ensure multiple blocks are requested
 	// concurrently during preprocessing.
@@ -465,7 +452,7 @@ func testReorgDuringPreprocess(t *testing.T, db backenddb.DB) {
 	}
 
 	// Preprocess.
-	err = svr.preProcessAccounts(testCtx(t))
+	err := svr.preProcessAccounts(testCtx(t))
 	require.NoError(t, err)
 
 	// Account balance should be the reorged-in balance.

--- a/backend/svc_block_test.go
+++ b/backend/svc_block_test.go
@@ -71,11 +71,8 @@ func testBlockEndpoint(t *testing.T, db backenddb.DB) {
 		c:               c,
 		db:              db,
 	}
-	ctxt, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	svr, err := NewServer(ctxt, cfg)
-	require.NoError(t, err)
-	err = svr.preProcessAccounts(testCtx(t))
+	svr := newTestServer(t, cfg)
+	err := svr.preProcessAccounts(testCtx(t))
 	require.NoError(t, err)
 
 	// Generate a block on the chain that isn't processed.

--- a/backend/svc_block_test.go
+++ b/backend/svc_block_test.go
@@ -153,7 +153,7 @@ func testBlockEndpoint(t *testing.T, db backenddb.DB) {
 
 	// Actual test function.
 	test := func(t *testing.T, tc *testCase) {
-		t.Parallel()
+		//t.Parallel()
 		res, rerr := svr.Block(context.Background(), tc.req)
 		if !types.RosettaErrorIs(rerr, tc.wantErr) {
 			t.Fatalf("unexpected error. want=%v got=%v",

--- a/backend/svc_construction_test.go
+++ b/backend/svc_construction_test.go
@@ -43,10 +43,7 @@ func TestConstructionDeriveEndpoint(t *testing.T) {
 		DBType:      dbTypePreconfigured,
 		c:           c,
 	}
-	ctxt, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	svr, err := NewServer(ctxt, cfg)
-	require.NoError(t, err)
+	svr := newTestServer(t, cfg)
 
 	type testCase struct {
 		name     string
@@ -279,10 +276,7 @@ func TestConstructionPreprocessEndpoint(t *testing.T) {
 		DBType:      dbTypePreconfigured,
 		c:           c,
 	}
-	ctxt, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	svr, err := NewServer(ctxt, cfg)
-	require.NoError(t, err)
+	svr := newTestServer(t, cfg)
 
 	type testCase struct {
 		name        string
@@ -354,10 +348,7 @@ func TestConstructionMetadataEndpoint(t *testing.T) {
 		DBType:      dbTypePreconfigured,
 		c:           c,
 	}
-	ctxt, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	svr, err := NewServer(ctxt, cfg)
-	require.NoError(t, err)
+	svr := newTestServer(t, cfg)
 
 	type testCase struct {
 		name    string
@@ -534,10 +525,7 @@ func TestConstructionPayloadsEndpoint(t *testing.T) {
 		DBType:      dbTypePreconfigured,
 		c:           c,
 	}
-	ctxt, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	svr, err := NewServer(ctxt, cfg)
-	require.NoError(t, err)
+	svr := newTestServer(t, cfg)
 
 	type testCase struct {
 		name         string
@@ -761,10 +749,7 @@ func TestConstructionParseEndpoint(t *testing.T) {
 		DBType:      dbTypePreconfigured,
 		c:           c,
 	}
-	ctxt, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	svr, err := NewServer(ctxt, cfg)
-	require.NoError(t, err)
+	svr := newTestServer(t, cfg)
 
 	type testCase struct {
 		name        string
@@ -991,10 +976,7 @@ func TestConstructionCombine(t *testing.T) {
 		DBType:      dbTypePreconfigured,
 		c:           c,
 	}
-	ctxt, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	svr, err := NewServer(ctxt, cfg)
-	require.NoError(t, err)
+	svr := newTestServer(t, cfg)
 
 	type genSig func(t *testing.T, tx *wire.MsgTx, i int) ([]byte, []byte)
 
@@ -1146,10 +1128,8 @@ func TestConstructionHashEndpoint(t *testing.T) {
 		DBType:      dbTypePreconfigured,
 		c:           c,
 	}
-	ctxt, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	svr, err := NewServer(ctxt, cfg)
-	require.NoError(t, err)
+
+	svr := newTestServer(t, cfg)
 
 	type testCase struct {
 		name       string
@@ -1223,10 +1203,7 @@ func TestConstructionSubmitEndpoint(t *testing.T) {
 		DBType:      dbTypePreconfigured,
 		c:           c,
 	}
-	ctxt, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	svr, err := NewServer(ctxt, cfg)
-	require.NoError(t, err)
+	svr := newTestServer(t, cfg)
 
 	type testCase struct {
 		name       string

--- a/backend/svc_mempool.go
+++ b/backend/svc_mempool.go
@@ -35,6 +35,10 @@ func (s *Server) Mempool(ctx context.Context, req *rtypes.NetworkRequest) (*rtyp
 
 func (s *Server) MempoolTransaction(ctx context.Context, req *rtypes.MempoolTransactionRequest) (*rtypes.MempoolTransactionResponse, *rtypes.Error) {
 
+	if err := s.isDcrdActive(); err != nil {
+		return nil, types.ErrChainUnavailable.Msg(err.Error()).RError()
+	}
+
 	var txh chainhash.Hash
 	err := chainhash.Decode(&txh, req.TransactionIdentifier.Hash)
 	if err != nil {

--- a/backend/svc_mempool_test.go
+++ b/backend/svc_mempool_test.go
@@ -29,10 +29,7 @@ func TestMempoolEndpoint(t *testing.T) {
 		DBType:      dbTypePreconfigured,
 		c:           c,
 	}
-	ctxt, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	svr, err := NewServer(ctxt, cfg)
-	require.NoError(t, err)
+	svr := newTestServer(t, cfg)
 
 	// Create a few dummy transactions.
 	tx1 := c.addSudoTx(1, []byte{})
@@ -107,10 +104,7 @@ func TestMempoolTransactionEndpoint(t *testing.T) {
 		DBType:      dbTypePreconfigured,
 		c:           c,
 	}
-	ctxt, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	svr, err := NewServer(ctxt, cfg)
-	require.NoError(t, err)
+	svr := newTestServer(t, cfg)
 
 	// Create a transaction which input we'll spend in the mempool. This is
 	// needed because during processing all inputs for a mempool tx are

--- a/backend/svc_network_test.go
+++ b/backend/svc_network_test.go
@@ -25,10 +25,7 @@ func TestNetworkListEndpoint(t *testing.T) {
 		DBType:      dbTypePreconfigured,
 		c:           c,
 	}
-	ctxt, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	svr, err := NewServer(ctxt, cfg)
-	require.NoError(t, err)
+	svr := newTestServer(t, cfg)
 
 	// Execute the NetworkList call.
 	res, rerr := svr.NetworkList(context.Background(), nil)
@@ -63,10 +60,7 @@ func TestNetworkOptionsEndpoint(t *testing.T) {
 		DBType:      dbTypePreconfigured,
 		c:           c,
 	}
-	ctxt, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	svr, err := NewServer(ctxt, cfg)
-	require.NoError(t, err)
+	svr := newTestServer(t, cfg)
 
 	// Execute the NetworkOptions call.
 	res, rerr := svr.NetworkOptions(context.Background(), nil)
@@ -94,10 +88,7 @@ func testNetworkStatusEndpoint(t *testing.T, db backenddb.DB) {
 		c:           c,
 		db:          db,
 	}
-	ctxt, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	svr, err := NewServer(ctxt, cfg)
-	require.NoError(t, err)
+	svr := newTestServer(t, cfg)
 
 	// Shorter function names to improve readability.
 	assertTip := func(hash *chainhash.Hash, index int64) {
@@ -131,7 +122,7 @@ func testNetworkStatusEndpoint(t *testing.T, db backenddb.DB) {
 	assertTip(&params.GenesisHash, 0)
 
 	// Preprocess the mock chain and generate an unprocessed block.
-	err = svr.preProcessAccounts(testCtx(t))
+	err := svr.preProcessAccounts(testCtx(t))
 	require.NoError(t, err)
 	c.mtx.Lock()
 	lastHash := c.tipHash

--- a/backend/sync.go
+++ b/backend/sync.go
@@ -150,7 +150,7 @@ func (s *Server) reorgToParentOf(ctx context.Context, bh *chainhash.Hash,
 		}
 
 		// Process the accounts modified by the block.
-		err = s.preProcessAccountBlock(s.ctx, nextTipHash, b, prev, nil)
+		err = s.preProcessAccountBlock(ctx, nextTipHash, b, prev, nil)
 		if err != nil {
 			return nil, fmt.Errorf("unable to process accounts of connected block "+
 				"%s: %v", nextTipHash, err)
@@ -178,7 +178,7 @@ func (s *Server) switchChainTo(ctx context.Context, bh *chainhash.Hash,
 	}
 
 	// Process the accounts modified by the block.
-	err = s.preProcessAccountBlock(s.ctx, bh, b, prev, utxoSet)
+	err = s.preProcessAccountBlock(ctx, bh, b, prev, utxoSet)
 	if err != nil {
 		return fmt.Errorf("unable to process accounts of connected block "+
 			"%s (height %d): %v", bh, b.Header.Height, err)
@@ -225,7 +225,7 @@ func (s *Server) handleBlockConnected(ctx context.Context, header *wire.BlockHea
 
 func (s *Server) handleBlockDisconnected(ctx context.Context, header *wire.BlockHeader) error {
 	blockHash := header.BlockHash()
-	err := s.db.Update(s.ctx, func(dbtx backenddb.WriteTx) error {
+	err := s.db.Update(ctx, func(dbtx backenddb.WriteTx) error {
 		// Ensure our current tip matches the chain rolled back by the
 		// disconnected block.
 		tipHash, tipHeight, err := s.db.LastProcessedBlock(dbtx)

--- a/backend/sync_test.go
+++ b/backend/sync_test.go
@@ -21,6 +21,8 @@ import (
 // TestProcessSequentialBlocks ensures the processSequentialBlocks function
 // behaves correctly even when blocks are fetched out of order.
 func TestProcessSequentialBlocks(t *testing.T) {
+	t.Parallel()
+
 	params := chaincfg.RegNetParams()
 	c := newMockChain(t, params)
 
@@ -35,10 +37,7 @@ func TestProcessSequentialBlocks(t *testing.T) {
 		DBType:      dbTypePreconfigured,
 		c:           c,
 	}
-	ctxt, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	svr, err := NewServer(ctxt, cfg)
-	require.NoError(t, err)
+	svr := newTestServer(t, cfg)
 
 	// Override concurrency to ensure multiple blocks are requested
 	// concurrently during preprocessing.
@@ -77,6 +76,8 @@ func TestProcessSequentialBlocks(t *testing.T) {
 }
 
 func testHandlesBlockNotifications(t *testing.T, db backenddb.DB) {
+	t.Parallel()
+
 	params := chaincfg.RegNetParams()
 	c := newMockChain(t, params)
 
@@ -101,10 +102,7 @@ func testHandlesBlockNotifications(t *testing.T, db backenddb.DB) {
 		c:           c,
 		db:          db,
 	}
-	ctxt, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	svr, err := NewServer(ctxt, cfg)
-	require.NoError(t, err)
+	svr := newTestServer(t, cfg)
 
 	// Helpful functions to drive the server forward.
 	tipHeader := func() *wire.BlockHeader {
@@ -150,7 +148,7 @@ func testHandlesBlockNotifications(t *testing.T, db backenddb.DB) {
 	c.extendTip(fromAddr(5, 1))
 
 	// Preprocess.
-	err = svr.preProcessAccounts(testCtx(t))
+	err := svr.preProcessAccounts(testCtx(t))
 	require.NoError(t, err)
 
 	// Account balance should be correct.

--- a/backend/sync_test.go
+++ b/backend/sync_test.go
@@ -269,7 +269,9 @@ func testHandlesBlockNotifications(t *testing.T, db backenddb.DB) {
 	}, {
 		name: "connect header from inexistent block",
 		test: func() {
-			var header wire.BlockHeader
+			header := wire.BlockHeader{
+				Height: uint32(c.tipHeight) + 1,
+			}
 			h1 := extendTip(toAddr(3, 1))
 			connectHeader(h1)
 
@@ -293,6 +295,16 @@ func testHandlesBlockNotifications(t *testing.T, db backenddb.DB) {
 			assertServerTip(h1.BlockHash())
 		},
 		wantBalance: 39,
+	}, {
+		name: "connect a block that was already connected",
+		test: func() {
+			h1 := extendTip(toAddr(3, 1))
+			h2 := extendTip(fromAddr(19, 1))
+			connectHeader(h1)
+			connectHeader(h2)
+			connectHeader(h1)
+		},
+		wantBalance: 23,
 	}}
 
 	for _, tc := range testCases {

--- a/main.go
+++ b/main.go
@@ -178,7 +178,7 @@ func _main() error {
 	}
 
 	// Create and start the backend Rosetta server.
-	drsvr, err := backend.NewServer(ctx, svrCfg)
+	drsvr, err := backend.NewServer(svrCfg)
 	if err != nil {
 		requestShutdown()
 		wg.Wait()

--- a/types/errors.go
+++ b/types/errors.go
@@ -58,6 +58,7 @@ const (
 	ErrIncorrectSigSize
 	ErrInvalidSig
 	ErrInvalidPubKey
+	ErrChainUnavailable
 
 	// This MUST be the last member.
 	nbErrorCodes
@@ -96,6 +97,7 @@ var errorCodeMsgs = map[ErrorCode]string{
 	ErrIncorrectSigSize:          "incorrect signature size",
 	ErrInvalidSig:                "invalid signature",
 	ErrInvalidPubKey:             "invalid public key",
+	ErrChainUnavailable:          "chain unavailable",
 }
 
 // Error returns the default error message for the given error code.


### PR DESCRIPTION
This series of commits improves handling of the underlying dcrd node. The following is a rough list of improvements:

- Handle connecting to an unsuitable dcrd node by disabling features which require remote access to the dcrd node
- Handle reconnecting to dcrd nodes that are behind on the chain (because they have been recreated for example)
- Drop the need for passing the a `Context` to NewServer