### PR TITLE
backend: Return peer list and sync status

### DIFF
--- a/backend/common_test.go
+++ b/backend/common_test.go
@@ -138,6 +138,7 @@ type mockChain struct {
 	versionHook            func(ctx context.Context) (map[string]chainjson.VersionResult, error)
 	getRawMempoolHook      func(ctx context.Context, txType chainjson.GetRawMempoolTxTypeCmd) ([]*chainhash.Hash, error)
 	sendRawTransactionHook func(ctx context.Context, tx *wire.MsgTx, allowHighFees bool) (*chainhash.Hash, error)
+	getPeerInfoHook        func(ctx context.Context) ([]chainjson.GetPeerInfoResult, error)
 }
 
 type blockMangler func(b *wire.MsgBlock)
@@ -403,6 +404,17 @@ func (mc *mockChain) Version(ctx context.Context) (map[string]chainjson.VersionR
 
 func (mc *mockChain) Connect(ctx context.Context, retry bool) error {
 	return nil
+}
+
+func (mc *mockChain) GetPeerInfo(ctx context.Context) ([]chainjson.GetPeerInfoResult, error) {
+	mc.mtx.Lock()
+	defer mc.mtx.Unlock()
+
+	if mc.getPeerInfoHook != nil {
+		return mc.getPeerInfoHook(ctx)
+	}
+
+	return []chainjson.GetPeerInfoResult{}, nil
 }
 
 // newTestServer returns a Server instance that is forced into the connected

--- a/backend/dcrd.go
+++ b/backend/dcrd.go
@@ -34,6 +34,9 @@ const (
 var (
 	errDcrdUnconnected = errors.New("dcrd instance not connected")
 	errDcrdUnsuitable  = errors.New("dcrd instance is unsuitable for dcrros operation")
+
+	syncStatusStageBlockchainSync     = "blockchain_sync"
+	syncStatusStageProcessingAccounts = "processing_accounts"
 )
 
 // chain specifies the functions needed by a backing chain implementation (an
@@ -168,6 +171,13 @@ func (s *Server) waitForBlockchainSync(ctx context.Context) error {
 
 			continue
 		}
+
+		// Update the current sync status.
+		s.mtx.Lock()
+		s.syncStatus.Stage = &syncStatusStageBlockchainSync
+		s.syncStatus.CurrentIndex = info.Blocks
+		s.syncStatus.TargetIndex = &info.SyncHeight
+		s.mtx.Unlock()
 
 		syncComplete := info.SyncHeight > 0 &&
 			!info.InitialBlockDownload &&

--- a/backend/dcrd.go
+++ b/backend/dcrd.go
@@ -50,6 +50,7 @@ type chain interface {
 	GetInfo(ctx context.Context) (*chainjson.InfoChainResult, error)
 	Version(ctx context.Context) (map[string]chainjson.VersionResult, error)
 	Connect(ctx context.Context, retry bool) error
+	GetPeerInfo(ctx context.Context) ([]chainjson.GetPeerInfoResult, error)
 }
 
 // checkDcrd verifies whether the specified dcrd instance fulfills the required

--- a/backend/dcrd_test.go
+++ b/backend/dcrd_test.go
@@ -313,6 +313,23 @@ func TestWaitsForBlockchainSync(t *testing.T) {
 			t.Fatalf("unexpected sync result. want=%v got=%v",
 				tc.wantSynced, gotSynced)
 		}
+
+		// Assert the sync status is the expected one.
+		svr.mtx.Lock()
+		gotSS := svr.syncStatus
+		svr.mtx.Unlock()
+		if gotSS.Stage == nil || *gotSS.Stage != syncStatusStageBlockchainSync {
+			t.Fatalf("unexpected syncStatus.Stage. want=%v got=%v",
+				syncStatusStageBlockchainSync, gotSS.Stage)
+		}
+		if gotSS.CurrentIndex != tc.resp.Blocks {
+			t.Fatalf("unexpected syncStatus.CurrentIndex. want=%d got=%d",
+				tc.resp.Blocks, gotSS.CurrentIndex)
+		}
+		if gotSS.TargetIndex == nil || *gotSS.TargetIndex != tc.resp.SyncHeight {
+			t.Fatalf("unexpected syncStatus.TargetIndex. want=%d got=%v",
+				tc.resp.SyncHeight, gotSS.TargetIndex)
+		}
 	}
 
 	for _, tc := range testCases {

--- a/backend/server.go
+++ b/backend/server.go
@@ -124,6 +124,7 @@ type Server struct {
 	blockNtfns     []*blockNtfn
 	blockNtfnsChan chan struct{}
 	ctx            context.Context
+	syncStatus     rtypes.SyncStatus
 }
 
 // NewServer creates a new server instance.
@@ -355,6 +356,11 @@ func (s *Server) Run(ctx context.Context) error {
 	if err := s.preProcessAccounts(ctx); err != nil {
 		return err
 	}
+
+	// All preprocessing is done, so clear the syncStatus var.
+	s.mtx.Lock()
+	s.syncStatus = rtypes.SyncStatus{}
+	s.mtx.Unlock()
 
 	// Now that we've processed the accounts, we can register for block
 	// notifications.

--- a/backend/server_test.go
+++ b/backend/server_test.go
@@ -14,6 +14,7 @@ import (
 
 	"decred.org/dcrros/backend/backenddb"
 	"decred.org/dcrros/backend/internal/memdb"
+	rtypes "github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/decred/dcrd/chaincfg/v3"
 	"github.com/decred/dcrd/wire"
 	"github.com/stretchr/testify/require"
@@ -243,6 +244,16 @@ func TestRunsAllDBTypes(t *testing.T) {
 
 			// Wait for run to stabilize.
 			time.Sleep(200 * time.Millisecond)
+
+			// The server's syncStatus should be empty.
+			svr.mtx.Lock()
+			gotSS := svr.syncStatus
+			svr.mtx.Unlock()
+			var emptySyncStatus rtypes.SyncStatus
+			if gotSS != emptySyncStatus {
+				t.Fatalf("unexpected sync status. want=%v, got=%v",
+					rtypes.SyncStatus{}, gotSS)
+			}
 
 			// Cancel the Run() call.
 			cancel()

--- a/backend/svc_network.go
+++ b/backend/svc_network.go
@@ -96,6 +96,10 @@ func (s *Server) NetworkStatus(ctx context.Context, req *rtypes.NetworkRequest) 
 		}
 	}
 
+	s.mtx.Lock()
+	syncStatus := s.syncStatus
+	s.mtx.Unlock()
+
 	return &rtypes.NetworkStatusResponse{
 		CurrentBlockIdentifier: &rtypes.BlockIdentifier{
 			Hash:  hash.String(),
@@ -105,6 +109,7 @@ func (s *Server) NetworkStatus(ctx context.Context, req *rtypes.NetworkRequest) 
 		GenesisBlockIdentifier: &rtypes.BlockIdentifier{
 			Hash: s.chainParams.GenesisHash.String(),
 		},
-		Peers: rpeers,
+		Peers:      rpeers,
+		SyncStatus: &syncStatus,
 	}, nil
 }


### PR DESCRIPTION
This adds some missing info for the `/network/status` call, namely: list of connected peers and the current sync status of the dcrros node.