### PR TITLE
backend: Make Construction methods usable in offline instance

### DIFF
--- a/backend/dcrd.go
+++ b/backend/dcrd.go
@@ -140,6 +140,15 @@ func isErrRPCOutOfRange(err error) bool {
 	return false
 }
 
+// isErrNoTxInfo returns true if the given error is an RPCError with a
+// ErrRPCNoTxInfo code.
+func isErrNoTxInfo(err error) bool {
+	if rpcerr, ok := err.(*dcrjson.RPCError); ok && rpcerr.Code == dcrjson.ErrRPCNoTxInfo {
+		return true
+	}
+	return false
+}
+
 // waitForBlockchainSync blocks until the underlying dcrd node is synced to the
 // best known chain.
 func (s *Server) waitForBlockchainSync(ctx context.Context) error {

--- a/backend/svc_construction.go
+++ b/backend/svc_construction.go
@@ -62,7 +62,16 @@ func (s *Server) ConstructionDerive(ctx context.Context,
 	if !ok {
 		return nil, types.ErrUnspecifiedAddressVersion.RError()
 	}
-	if version != float64(0) {
+	var wantVers interface{}
+	switch version.(type) {
+	case uint16:
+		wantVers = uint16(0)
+	case float64:
+		wantVers = float64(0)
+	case int:
+		wantVers = int(0)
+	}
+	if version != wantVers {
 		return nil, types.ErrUnsupportedAddressVersion.RError()
 	}
 

--- a/backend/svc_construction_test.go
+++ b/backend/svc_construction_test.go
@@ -798,7 +798,7 @@ func TestConstructionParseEndpoint(t *testing.T) {
 		ins:     []*wire.TxIn{debitNoPrevTxIn},
 		outs:    []*wire.TxOut{creditOut},
 		signed:  false,
-		wantErr: types.ErrUnknown,
+		wantErr: types.ErrPrevOutTxNotFound,
 	}, {
 		name: "invalid hex",
 		forceReq: &rtypes.ConstructionParseRequest{
@@ -850,10 +850,9 @@ func TestConstructionParseEndpoint(t *testing.T) {
 			}
 		}
 		res, rerr := svr.ConstructionParse(context.Background(), req)
-		gotErr := rerr != nil
 		if !types.RosettaErrorIs(rerr, tc.wantErr) {
 			t.Fatalf("unexpected error. want=%v got=%v",
-				tc.wantErr, gotErr)
+				tc.wantErr, rerr)
 		}
 
 		if tc.wantErr != nil {

--- a/types/address_test.go
+++ b/types/address_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	rtypes "github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/chaincfg/v3"
 )
 
@@ -21,6 +22,15 @@ func mustHex(s string) []byte {
 		panic(err)
 	}
 	return b
+}
+
+// mustHash decodes the given string as a chainhash.Hash value or panics.
+func mustHash(s string) chainhash.Hash {
+	var h chainhash.Hash
+	if err := chainhash.Decode(&h, s); err != nil {
+		panic(err)
+	}
+	return h
 }
 
 // TestDcrPkScriptToRosetta tests that converting pkscripts to Rosetta

--- a/types/errors.go
+++ b/types/errors.go
@@ -59,6 +59,8 @@ const (
 	ErrInvalidSig
 	ErrInvalidPubKey
 	ErrChainUnavailable
+	ErrPrevOutTxNotFound
+	ErrPrevOutIndexNotFound
 
 	// This MUST be the last member.
 	nbErrorCodes
@@ -98,6 +100,8 @@ var errorCodeMsgs = map[ErrorCode]string{
 	ErrInvalidSig:                "invalid signature",
 	ErrInvalidPubKey:             "invalid public key",
 	ErrChainUnavailable:          "chain unavailable",
+	ErrPrevOutTxNotFound:         "previous output tx not found",
+	ErrPrevOutIndexNotFound:      "previous output tx index not found",
 }
 
 // Error returns the default error message for the given error code.


### PR DESCRIPTION
The Rosetta spec requires some of the Construction API operations to be performed in offline environments, which don't have a backing node implementation connected to the larger network. Only the `/construction/metadata` and `/construction/submit` are meant to be executed in online environments.

Because of this design restriction, additional information needs to be passed between a few select calls, most notably the `/construction/parse` method, which needs the previous output information (pkscript, version and amount) to be able to convert a Decred tx to a set of Rosetta Operations.

In this PR we switch the encoding of the transactions that are returned by the `/construction/payload` and `/construction/combine` methods to use a new `constructionTx` structure, serialized into a binary byte array and encoded as an hex string as required by the Rosetta spec for those methods

This new structure can carry both the raw decred transaction and additional data needed to properly parse the transaction in future `/construction/parse` calls.