### PR TITLE
multi: Rename PrevInputs to PrevOutputs

### DIFF
--- a/backend/svc_block_test.go
+++ b/backend/svc_block_test.go
@@ -191,8 +191,9 @@ func TestBlockEndpoint(t *testing.T) {
 	testDbInstances(t, true, testBlockEndpoint)
 }
 
-// TestInputsFetcher verifies the inputsFetcher function behaves as expected.
-func TestInputsFetcher(t *testing.T) {
+// TestPrevOutsFetcher verifies the PrevOutsFetcher function behaves as
+// expected.
+func TestPrevOutsFetcher(t *testing.T) {
 	t.Parallel()
 
 	params := chaincfg.RegNetParams()
@@ -221,7 +222,7 @@ func TestInputsFetcher(t *testing.T) {
 
 	type testCase struct {
 		name         string
-		utxoSet      map[wire.OutPoint]*types.PrevInput
+		utxoSet      map[wire.OutPoint]*types.PrevOutput
 		reqOutPoints []*wire.OutPoint
 		forceErr     error
 		wantErr      error
@@ -233,7 +234,7 @@ func TestInputsFetcher(t *testing.T) {
 		reqOutPoints: []*wire.OutPoint{&correctOutPoint0},
 	}, {
 		name: "prevout exists in utxo set",
-		utxoSet: map[wire.OutPoint]*types.PrevInput{
+		utxoSet: map[wire.OutPoint]*types.PrevOutput{
 			correctOutPoint0: nil,
 		},
 		reqOutPoints: []*wire.OutPoint{&correctOutPoint0},
@@ -246,21 +247,21 @@ func TestInputsFetcher(t *testing.T) {
 	}, {
 		name:         "different prevouts from same tx in utxo set",
 		reqOutPoints: []*wire.OutPoint{&correctOutPoint0, &correctOutPoint1},
-		utxoSet: map[wire.OutPoint]*types.PrevInput{
+		utxoSet: map[wire.OutPoint]*types.PrevOutput{
 			correctOutPoint0: nil,
 			correctOutPoint1: nil,
 		},
 	}, {
 		name:         "different prevouts from same tx partially in utxo set",
 		reqOutPoints: []*wire.OutPoint{&correctOutPoint0, &correctOutPoint1},
-		utxoSet: map[wire.OutPoint]*types.PrevInput{
+		utxoSet: map[wire.OutPoint]*types.PrevOutput{
 			correctOutPoint0: nil,
 		},
 	}, {
 		name: "different prevouts partially in utxo set",
 		reqOutPoints: []*wire.OutPoint{&correctOutPoint0,
 			&correctOutPoint1, &correctOutPointTx2},
-		utxoSet: map[wire.OutPoint]*types.PrevInput{
+		utxoSet: map[wire.OutPoint]*types.PrevOutput{
 			correctOutPointTx2: nil,
 		},
 	}, {
@@ -288,7 +289,7 @@ func TestInputsFetcher(t *testing.T) {
 			return c.getRawTransaction(ctx, txHash)
 		}
 
-		res, err := svr.inputsFetcher(testCtx(t), tc.utxoSet,
+		res, err := svr.prevOutsFetcher(testCtx(t), tc.utxoSet,
 			tc.reqOutPoints...)
 		if !errors.Is(err, tc.wantErr) {
 			t.Fatalf("unexpected error. want=%v, got=%v",

--- a/backend/svc_construction_test.go
+++ b/backend/svc_construction_test.go
@@ -232,7 +232,7 @@ func TestConstructionTxSerialize(t *testing.T) {
 				TxIn:  []*wire.TxIn{},
 				TxOut: []*wire.TxOut{},
 			},
-			prevOutPoints: map[wire.OutPoint]*types.PrevInput{},
+			prevOutPoints: map[wire.OutPoint]*types.PrevOutput{},
 		},
 		wantStr: "0100000000000000000000000000000000",
 	}, {
@@ -242,7 +242,7 @@ func TestConstructionTxSerialize(t *testing.T) {
 				TxIn:  []*wire.TxIn{{SignatureScript: []byte{}}},
 				TxOut: []*wire.TxOut{{PkScript: []byte{}}},
 			},
-			prevOutPoints: map[wire.OutPoint]*types.PrevInput{
+			prevOutPoints: map[wire.OutPoint]*types.PrevOutput{
 				{}: {PkScript: []byte{}},
 			},
 		},
@@ -268,7 +268,7 @@ func TestConstructionTxSerialize(t *testing.T) {
 					PkScript: slice2,
 				}},
 			},
-			prevOutPoints: map[wire.OutPoint]*types.PrevInput{
+			prevOutPoints: map[wire.OutPoint]*types.PrevOutput{
 				prevOut1: {
 					Amount:   0x2121212121212121,
 					Version:  0x8787,
@@ -301,7 +301,7 @@ func TestConstructionTxSerialize(t *testing.T) {
 					PkScript: slice2,
 				}},
 			},
-			prevOutPoints: map[wire.OutPoint]*types.PrevInput{
+			prevOutPoints: map[wire.OutPoint]*types.PrevOutput{
 				prevOut2: {
 					PkScript: []byte{},
 				},
@@ -323,7 +323,7 @@ func TestConstructionTxSerialize(t *testing.T) {
 				}},
 				TxOut: []*wire.TxOut{{PkScript: []byte{}}},
 			},
-			prevOutPoints: map[wire.OutPoint]*types.PrevInput{
+			prevOutPoints: map[wire.OutPoint]*types.PrevOutput{
 				{}: {PkScript: []byte{}},
 			},
 		},
@@ -338,7 +338,7 @@ func TestConstructionTxSerialize(t *testing.T) {
 				}},
 				TxOut: []*wire.TxOut{{PkScript: []byte{}}},
 			},
-			prevOutPoints: map[wire.OutPoint]*types.PrevInput{},
+			prevOutPoints: map[wire.OutPoint]*types.PrevOutput{},
 		},
 		wantErr: errWrongNbPrevOuts,
 	}}
@@ -400,7 +400,7 @@ func TestConstructionTxDeserialize(t *testing.T) {
 				TxIn:  []*wire.TxIn{},
 				TxOut: []*wire.TxOut{},
 			},
-			prevOutPoints: map[wire.OutPoint]*types.PrevInput{},
+			prevOutPoints: map[wire.OutPoint]*types.PrevOutput{},
 		},
 	}, {
 		name:       "one input, one output both empty",
@@ -410,7 +410,7 @@ func TestConstructionTxDeserialize(t *testing.T) {
 				TxIn:  []*wire.TxIn{{SignatureScript: []byte{}}},
 				TxOut: []*wire.TxOut{{PkScript: []byte{}}},
 			},
-			prevOutPoints: map[wire.OutPoint]*types.PrevInput{
+			prevOutPoints: map[wire.OutPoint]*types.PrevOutput{
 				{}: {PkScript: []byte{}},
 			},
 		},
@@ -436,7 +436,7 @@ func TestConstructionTxDeserialize(t *testing.T) {
 					PkScript: slice2,
 				}},
 			},
-			prevOutPoints: map[wire.OutPoint]*types.PrevInput{
+			prevOutPoints: map[wire.OutPoint]*types.PrevOutput{
 				prevOut1: {
 					Amount:   0x2121212121212121,
 					Version:  0x8787,
@@ -469,7 +469,7 @@ func TestConstructionTxDeserialize(t *testing.T) {
 					PkScript: slice2,
 				}},
 			},
-			prevOutPoints: map[wire.OutPoint]*types.PrevInput{
+			prevOutPoints: map[wire.OutPoint]*types.PrevOutput{
 				prevOut2: {
 					PkScript: []byte{},
 				},
@@ -1060,7 +1060,7 @@ func TestConstructionParseEndpoint(t *testing.T) {
 		if req == nil {
 			ctrtx := new(constructionTx)
 			ctrtx.tx = tx
-			ctrtx.prevOutPoints, err = types.ExtractPrevInputsFromOps(tc.wantOps, params)
+			ctrtx.prevOutPoints, err = types.ExtractPrevOutputsFromOps(tc.wantOps, params)
 			require.NoError(t, err)
 			sertx, err := ctrtx.serialize()
 			require.NoError(t, err)
@@ -1288,7 +1288,7 @@ func TestConstructionCombine(t *testing.T) {
 		var err error
 		ctrtx := new(constructionTx)
 		ctrtx.tx = tx
-		ctrtx.prevOutPoints, err = types.ExtractPrevInputsFromOps(tc.debits, params)
+		ctrtx.prevOutPoints, err = types.ExtractPrevOutputsFromOps(tc.debits, params)
 		require.NoError(t, err)
 		serTx, err := ctrtx.serialize()
 		require.NoError(t, err)
@@ -1346,7 +1346,7 @@ func TestConstructionHashEndpoint(t *testing.T) {
 	dummyTxh := dummyTx.TxHash()
 	ctrtx := &constructionTx{
 		tx: dummyTx,
-		prevOutPoints: map[wire.OutPoint]*types.PrevInput{
+		prevOutPoints: map[wire.OutPoint]*types.PrevOutput{
 			{}: {},
 		},
 	}
@@ -1426,7 +1426,7 @@ func TestConstructionSubmitEndpoint(t *testing.T) {
 	dummyTxh := dummyTx.TxHash()
 	ctrtx := &constructionTx{
 		tx: dummyTx,
-		prevOutPoints: map[wire.OutPoint]*types.PrevInput{
+		prevOutPoints: map[wire.OutPoint]*types.PrevOutput{
 			{}: {},
 		},
 	}

--- a/backend/svc_mempool.go
+++ b/backend/svc_mempool.go
@@ -54,8 +54,8 @@ func (s *Server) MempoolTransaction(ctx context.Context, req *rtypes.MempoolTran
 	}
 
 	// TODO: What if the returned tx has already been mined?
-	fetchInputs := s.makeInputsFetcher(ctx, nil)
-	rtx, err := types.MempoolTxToRosetta(tx.MsgTx(), fetchInputs, s.chainParams)
+	fetchPrevOuts := s.makePrevOutsFetcher(ctx, nil)
+	rtx, err := types.MempoolTxToRosetta(tx.MsgTx(), fetchPrevOuts, s.chainParams)
 	if err != nil {
 		return nil, types.RError(err)
 	}

--- a/backend/sync.go
+++ b/backend/sync.go
@@ -79,8 +79,8 @@ func (s *Server) rollbackTip(dbtx backenddb.WriteTx, tipHash *chainhash.Hash,
 	}
 
 	// Process the rolled back block.
-	fetchInputs := s.makeInputsFetcher(dbtx.Context(), nil)
-	err = types.IterateBlockOps(b, prev, fetchInputs, applyOp, s.chainParams)
+	fetchPrevOuts := s.makePrevOutsFetcher(dbtx.Context(), nil)
+	err = types.IterateBlockOps(b, prev, fetchPrevOuts, applyOp, s.chainParams)
 	if err != nil {
 		return err
 	}
@@ -243,7 +243,7 @@ func (s *Server) reorgToParentOf(ctx context.Context, bh *chainhash.Hash,
 // switchChainTo switches the DB chain to the specified block, handling reorgs
 // as necessary.
 func (s *Server) switchChainTo(ctx context.Context, bh *chainhash.Hash,
-	b *wire.MsgBlock, utxoSet map[wire.OutPoint]*types.PrevInput) error {
+	b *wire.MsgBlock, utxoSet map[wire.OutPoint]*types.PrevOutput) error {
 
 	// Reorg (if needed) to the parent of the passed block.
 	prev, err := s.reorgToParentOf(ctx, bh, b)

--- a/types/transactions_test.go
+++ b/types/transactions_test.go
@@ -693,15 +693,15 @@ func TestCombineSigs(t *testing.T) {
 	}
 }
 
-// TestExtractPrevInputsFromOps ensures the ExtractPRevInputsFromOps behaves as
+// TestExtractPrevOutputsFromOps ensures the ExtractPRevInputsFromOps behaves as
 // expected.
-func TestExtractPrevInputsFromOps(t *testing.T) {
+func TestExtractPrevOutputsFromOps(t *testing.T) {
 	chainParams := chaincfg.RegNetParams()
 
 	type testCase struct {
 		name    string
 		ops     []*rtypes.Operation
-		target  map[wire.OutPoint]*PrevInput
+		target  map[wire.OutPoint]*PrevOutput
 		wantErr bool
 	}
 
@@ -713,13 +713,13 @@ func TestExtractPrevInputsFromOps(t *testing.T) {
 	testCases := []testCase{{
 		name:   "no ops",
 		ops:    []*rtypes.Operation{},
-		target: map[wire.OutPoint]*PrevInput{},
+		target: map[wire.OutPoint]*PrevOutput{},
 	}, {
 		name: "no debits",
 		ops: []*rtypes.Operation{{
 			Type: "credit",
 		}},
-		target: map[wire.OutPoint]*PrevInput{},
+		target: map[wire.OutPoint]*PrevOutput{},
 	}, {
 		name: "one debit",
 		ops: []*rtypes.Operation{{
@@ -738,7 +738,7 @@ func TestExtractPrevInputsFromOps(t *testing.T) {
 				CoinAction: "coin_spent",
 			},
 		}},
-		target: map[wire.OutPoint]*PrevInput{
+		target: map[wire.OutPoint]*PrevOutput{
 			{Hash: hashHash1, Index: 1}: {
 				PkScript: mustHex("76a91438336cea45bafa04c6c1dab1e588c8ce7de3a71b88ac"),
 				Amount:   10,
@@ -778,7 +778,7 @@ func TestExtractPrevInputsFromOps(t *testing.T) {
 				CoinAction: "coin_spent",
 			},
 		}},
-		target: map[wire.OutPoint]*PrevInput{
+		target: map[wire.OutPoint]*PrevOutput{
 			{Hash: hashHash1, Index: 1}: {
 				PkScript: mustHex("76a91438336cea45bafa04c6c1dab1e588c8ce7de3a71b88ac"),
 				Amount:   10,
@@ -852,7 +852,7 @@ func TestExtractPrevInputsFromOps(t *testing.T) {
 	}}
 
 	test := func(t *testing.T, tc *testCase) {
-		gotMap, err := ExtractPrevInputsFromOps(tc.ops, chainParams)
+		gotMap, err := ExtractPrevOutputsFromOps(tc.ops, chainParams)
 		gotErr := err != nil
 		if gotErr != tc.wantErr {
 			t.Fatalf("unexpected error. want=%v, got=%v, err=%v",


### PR DESCRIPTION
PrevInputs is ambigous, since the data held by this is struct is
actually data about outputs that were spent by some given input.

This PR only has renaming code changes and should not have any functional changes. 