### PR TITLE
multi: Add E2E Test Suite

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,11 @@
+name: Docker Build Production Image
+on: [push, pull_request]
+
+jobs:
+  build-stable:
+    name: Build latest stable version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build the production Docker image
+        run: docker build -t decred/dcrros:$(date +%s) .

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,98 @@
+name: E2E Test Suite
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build E2E Binaries
+    runs-on: ubuntu-latest
+    env:
+      GO111MODULE: "on"
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+
+      - name: Checkout dcrd
+        uses: actions/checkout@v2
+        with:
+          repository: decred/dcrd
+          ref: release-v1.6.0
+          path: dcrd
+      - name: Checkout dcrwallet
+        uses: actions/checkout@v2
+        with:
+          repository: decred/dcrwallet
+          ref: release-v1.6.0
+          path: dcrwallet
+      - name: Checkout rosetta-cli
+        uses: actions/checkout@v2
+        with:
+          repository: coinbase/rosetta-cli
+          ref: v0.6.7
+          path: rosetta-cli
+      - name: Checkout dcrros
+        uses: actions/checkout@v2
+        with:
+          path: dcrros
+
+      - name: Manage build cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Build dcrd
+        working-directory: dcrd
+        run: go install .
+      - name: Build dcrwallet
+        working-directory: dcrwallet
+        run: go install .
+      - name: Build rosetta-cli
+        working-directory: rosetta-cli
+        run: go install .
+      - name: Build dcrros
+        working-directory: dcrros
+        run: go install .
+      - name: Build e2etest
+        working-directory: dcrros
+        run: go install ./internal/e2etest
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: dcrros-e2e-bins
+          path: ~/go/bin
+
+  e2etest:
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        dbtype: [mem, badger, badgermem]
+    name: E2E Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: dcrros-e2e-bins
+          path: ~/bin
+      - name: Setup the PATH env
+        run: |
+          echo "$HOME/bin" >> $GITHUB_PATH
+          chmod -R a+rx "$HOME/bin"
+      - name: Run e2etest
+        run: e2etest -debuglevel debug -appdata /tmp/data
+      - name: Upload test results
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: e2e-results-${{ matrix.dbtype }}
+          path: /tmp/data/*.log
+
+

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -8,10 +8,10 @@ FROM golang:1.15-buster AS builder
 # Build the latest dcrd and dcrctl. The commented lines allow you to pick
 # a specific version if needed.
 RUN git clone https://github.com/decred/dcrd
-# RUN (cd dcrd && git checkout [commit hash])
+RUN (cd dcrd && git checkout release-v1.6)
 RUN (cd dcrd && go install .)
 RUN git clone https://github.com/decred/dcrctl
-# RUN (cd dcrctl && git checkout [commit hash])
+RUN (cd dcrctl && git checkout release-v1.6)
 RUN (cd dcrctl && go install .)
 
 # Build from the current dir.

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,0 +1,39 @@
+# This is the Dockerfile for the End-to-End (E2E) test suite.
+#
+# The E2E test suite uses dcrd and dcrwallet to setup an extensive simnet, runs
+# both online and offline dcrros instances and performs rosetta-cli's
+# check:data and check:construction tests to assert correct behavior of the
+# code.
+
+# Stage 1: Build the bins in a golang image.
+FROM golang:1.15-buster AS builder
+
+# Build dcrd, dcrwallet, dcrros and include dcrctl as well.
+#
+# Versions for the bins are updated as required by the current master version
+# of dcrros.
+RUN git clone https://github.com/decred/dcrd
+RUN (cd dcrd && git checkout release-v1.6.0 && go install .)
+RUN git clone https://github.com/decred/dcrwallet
+RUN (cd dcrwallet && git checkout release-v1.6.0 && go install .)
+RUN git clone https://github.com/coinbase/rosetta-cli
+RUN (cd rosetta-cli && git checkout v0.6.7 && go install .)
+copy . dcrros
+RUN (cd dcrros && go install .)
+RUN (cd dcrros/internal/e2etest && go install .)
+
+# Stage 2: Build the final image starting from a cleaner base.
+FROM debian:buster
+
+# Copy the previously built bins.
+COPY --from=builder /go/bin/dcrd bin/dcrd
+COPY --from=builder /go/bin/dcrwallet bin/dcrwallet
+COPY --from=builder /go/bin/dcrros bin/dcrros
+COPY --from=builder /go/bin/rosetta-cli bin/rosetta-cli
+COPY --from=builder /go/bin/e2etest bin/e2etest
+
+# According to Rosetta's documentation, all data should be in /data.
+WORKDIR /data
+
+# The main executable for this is the e2etest bin.
+ENTRYPOINT ["e2etest", "-debuglevel=debug", "-appdata=/data"]

--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ For additional configuration options, including how to run on the test network, 
 
 `dcrros` is currently developed on go version 1.14. It follows the same conventions as other Decred tools, such as [dcrd](https://github.com/decred/dcrd) and [dcrwallet](https://github.com/decred/dcrwallet).
 
+# E2E Testing
+
+An End-to-End test suite, including running the Rosetta CLI's `check:data` and `check:construction` tests is included in [/internal/e2etest](/internal/e2etest). This test suite runs on a local simnet instance that exercises a large number of common on-chain operations found in the Decred chain.
+
+The tests can also be run via Docker by using the included [Dockerfile.e2e](/Dockerfile.e2e):
+
+```shell
+$ docker build --tag dcrros:e2e -f Dockerfile.e2e .
+$ docker run --rm dcrros:e2e
+```
+
 # License
 
 `dcrros` is licensed under the [copyfree](http://copyfree.org) ISC License.

--- a/backend/server.go
+++ b/backend/server.go
@@ -357,7 +357,7 @@ func (s *Server) Run(ctx context.Context) error {
 	if err := s.waitForDcrdConnection(ctx); err != nil {
 		return err
 	}
-	peerTimeout := 10 * time.Second
+	peerTimeout := 30 * time.Second
 	if s.peerTimeout != 0 {
 		peerTimeout = s.peerTimeout
 	}

--- a/config.go
+++ b/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Decred developers
+// Copyright (c) 2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -55,11 +55,11 @@ func (c chainNetwork) defaultListenPort() string {
 func (c chainNetwork) defaultDcrdRPCConnect() string {
 	switch c {
 	case cnMainNet:
-		return "localhost:9109"
+		return "127.0.0.1:9109"
 	case cnTestNet:
-		return "localhost:19109"
+		return "127.0.0.1:19109"
 	case cnSimNet:
-		return "localhost:19556"
+		return "127.0.0.1:19556"
 	default:
 		panic("unknown chainNetwork")
 	}
@@ -105,7 +105,7 @@ type config struct {
 
 	// Dcrd Connection Options
 
-	DcrdConnect   string `short:"c" long:"dcrdconnect" description:"Network address of the RPC interface of the dcrd node to connect to (default: localhost port 9109, testnet: 19109, simnet: 19556)"`
+	DcrdConnect   string `short:"c" long:"dcrdconnect" description:"Network address of the RPC interface of the dcrd node to connect to (default: 127.0.0.1 port 9109, testnet: 19109, simnet: 19556)"`
 	DcrdCertPath  string `long:"dcrdcertpath" description:"File path location of the dcrd RPC certificate"`
 	DcrdCertBytes string `long:"dcrdcertbytes" description:"The pem-encoded RPC certificate for dcrd"`
 	DcrdUser      string `short:"u" long:"dcrduser" description:"RPC username to authenticate with dcrd"`
@@ -183,6 +183,9 @@ func (c *config) dcrdArgs() []string {
 	}
 	if c.SimNet {
 		args = append(args, "--simnet")
+	}
+	if c.DcrdConnect != "" {
+		args = append(args, "--rpclisten="+c.DcrdConnect)
 	}
 
 	args = append(args, c.DcrdExtraArgs...)
@@ -564,13 +567,6 @@ func loadConfig() (*config, []string, error) {
 			return nil, nil, fmt.Errorf("profile address %s: port "+
 				"must be between 1024 and 65535", cfg.Profile)
 		}
-	}
-
-	// When using --rundcrd the user shouldn't specify a connection option
-	// as we'll specify one for them.
-	if cfg.DcrdConnect != "" && cfg.RunDcrd != "" {
-		return nil, nil, fmt.Errorf("cannot use both --dcrdconnect and " +
-			"--rundcrd at the same time")
 	}
 
 	// Determine the default dcrd connect address based on the selected

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module decred.org/dcrros
 go 1.14
 
 require (
+	decred.org/dcrwallet v1.6.0
 	github.com/coinbase/rosetta-sdk-go v0.6.1
 	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/dcrd v1.2.1-0.20210121192504-91b84e06447e
@@ -20,8 +21,9 @@ require (
 	github.com/decred/dcrd/wire v1.4.0
 	github.com/decred/slog v1.1.0
 	github.com/dgraph-io/badger/v2 v2.2007.2
-	github.com/jessevdk/go-flags v1.4.0
+	github.com/jessevdk/go-flags v1.4.1-0.20200711081900-c17162fe8fd7
 	github.com/jrick/logrotate v1.0.0
+	github.com/jrick/wsrpc/v2 v2.3.4
 	github.com/matheusd/middlelogger v0.1.1
 	github.com/stretchr/testify v1.6.2-0.20200818115829-54d05a4e1844
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+decred.org/cspp v0.3.0/go.mod h1:UygjYilC94dER3BEU65Zzyoqy9ngJfWCD2rdJqvUs2A=
+decred.org/dcrwallet v1.6.0 h1:AyyarDNewxOEXPB8CmXioD7Dk3x6omG1hVbE9Hil9CY=
+decred.org/dcrwallet v1.6.0/go.mod h1:deeiKo2RpnmPpGfmNR2fFupdq5D+fFubA8js29YjDDc=
 github.com/Azure/azure-pipeline-go v0.2.1/go.mod h1:UGSo8XybXnIGZ3epmeBw7Jdz+HiUVpqIlpz/HKHylF4=
 github.com/Azure/azure-pipeline-go v0.2.2/go.mod h1:4rQ/NZncSvGqNkkOsNpOU1tgoNuIlp9AfUH5G1tvCHc=
 github.com/Azure/azure-storage-blob-go v0.7.0/go.mod h1:f9YQKtsG1nMisotuTPpO0tjNuEjKRYAcJU8/ydDI++4=
@@ -55,6 +58,7 @@ github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghf
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cloudflare-go v0.10.2-0.20190916151808-a80f83b9add9/go.mod h1:1MxXX1Ux4x6mqPmjkUgTP1CdXIBXKX7T+Jk9Gxrmx+U=
+github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/coinbase/rosetta-sdk-go v0.6.1 h1:aOb5qstlX0uqP9HRC7wCY+YAZDzZbS2C/i3Qy/lR3xM=
 github.com/coinbase/rosetta-sdk-go v0.6.1/go.mod h1:t36UuaD4p2DSXaSH9IwMasZDJ7UPxt9cQi6alS5OPTo=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -79,6 +83,7 @@ github.com/decred/dcrd/blockchain/stake/v3 v3.0.0 h1:vr0o0ICjuEzg1End6YtBfwgDuPk
 github.com/decred/dcrd/blockchain/stake/v3 v3.0.0/go.mod h1:5GIUwsrHQCJauacgCegIR6t92SaeVi28Qls/BLN9vOw=
 github.com/decred/dcrd/blockchain/standalone/v2 v2.0.0 h1:9gUuH0u/IZNPWBK9K3CxgAWPG7nTqVSsZefpGY4Okns=
 github.com/decred/dcrd/blockchain/standalone/v2 v2.0.0/go.mod h1:t2qaZ3hNnxHZ5kzVJDgW5sp47/8T5hYJt7SR+/JtRhI=
+github.com/decred/dcrd/blockchain/v3 v3.0.2/go.mod h1:LD5VA95qdb+DlRiPI8VLBimDqvlDCAJsidZ5oD6nc/U=
 github.com/decred/dcrd/blockchain/v3 v3.0.3/go.mod h1:LD5VA95qdb+DlRiPI8VLBimDqvlDCAJsidZ5oD6nc/U=
 github.com/decred/dcrd/certgen v1.1.1 h1:MYPG5jCysnbF4OiJ1++YumFEu2p/MsM/zxmmqC9mVFg=
 github.com/decred/dcrd/certgen v1.1.1/go.mod h1:ivkPLChfjdAgFh7ZQOtl6kJRqVkfrCq67dlq3AbZBQE=
@@ -117,6 +122,7 @@ github.com/decred/dcrd/rpcclient/v6 v6.0.2 h1:bPHPeKGrPZPsHDSRIJxj5xhqoxwM5R7+Os
 github.com/decred/dcrd/rpcclient/v6 v6.0.2/go.mod h1:t6ECC72j2xWQ323poL85IFNq0EUfcSTfwL8j7jDJ6mw=
 github.com/decred/dcrd/txscript/v3 v3.0.0 h1:74NmirXAIskbGP0g9OWtrmN7OxDbWJ9G73a5uoxTkcM=
 github.com/decred/dcrd/txscript/v3 v3.0.0/go.mod h1:pdvnlD4KGdDoc09cvWRJ8EoRQUaiUz41uDevOWuEfII=
+github.com/decred/dcrd/wire v1.3.0/go.mod h1:fnKGlUY2IBuqnpxx5dYRU5Oiq392OBqAuVjRVSkIoXM=
 github.com/decred/dcrd/wire v1.4.0 h1:KmSo6eTQIvhXS0fLBQ/l7hG7QLcSJQKSwSyzSqJYDk0=
 github.com/decred/dcrd/wire v1.4.0/go.mod h1:WxC/0K+cCAnBh+SKsRjIX9YPgvrjhmE+6pZlel1G7Ro=
 github.com/decred/go-socks v1.1.0 h1:dnENcc0KIqQo3HSXdgboXAHgqsCIutkqq6ntQjYtm2U=
@@ -140,7 +146,9 @@ github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dvyukov/go-fuzz v0.0.0-20200318091601-be3528f3a813/go.mod h1:11Gm+ccJnvAhCNLlf5+cS9KjtbaD5I5zaZpFMsTHWTw=
 github.com/edsrzf/mmap-go v0.0.0-20160512033002-935e0e8a636c/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
+github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
+github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/ethereum/go-ethereum v1.9.24/go.mod h1:JIfVb6esrqALTExdz9hRYvrP0xBDf6wCncIu1hNwHpM=
 github.com/fatih/color v1.3.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
@@ -161,6 +169,7 @@ github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=
 github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrUpVNzEA03Pprs=
@@ -183,6 +192,7 @@ github.com/google/gofuzz v1.1.1-0.20200604201612-c04b05f3adfa/go.mod h1:dBl0BpW6
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.1-0.20190629185528-ae1634f6a989/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/graph-gophers/graphql-go v0.0.0-20191115155744-f33e81362277/go.mod h1:9CQHMSxwO4MprSdzoIEobiHpoLtHm77vfxsvsIN5Vuc=
@@ -198,10 +208,15 @@ github.com/jackpal/go-nat-pmp v1.0.2-0.20160603034137-1fa385a6f458/go.mod h1:QPH
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/jessevdk/go-flags v1.4.1-0.20200711081900-c17162fe8fd7 h1:Ug59miTxVKVg5Oi2S5uHlKOIV5jBx4Hb2u0jIxxDaSs=
+github.com/jessevdk/go-flags v1.4.1-0.20200711081900-c17162fe8fd7/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jrick/bitset v1.0.0/go.mod h1:ZOYB5Uvkla7wIEY4FEssPVi3IQXa02arznRaYaAEPe4=
 github.com/jrick/logrotate v1.0.0 h1:lQ1bL/n9mBNeIXoTUoYRlK4dHuNJVofX9oWqBtPnSzI=
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=
+github.com/jrick/wsrpc/v2 v2.3.2/go.mod h1:XPYs8BnRWl99lCvXRM5SLpZmTPqWpSOPkDIqYTwDPfU=
+github.com/jrick/wsrpc/v2 v2.3.4 h1:+GzRtp/TyXaSB61pN92lIAVyvdVv0RSqniIEB/rPx1Q=
+github.com/jrick/wsrpc/v2 v2.3.4/go.mod h1:XPYs8BnRWl99lCvXRM5SLpZmTPqWpSOPkDIqYTwDPfU=
 github.com/julienschmidt/httprouter v1.1.1-0.20170430222011-975b5c4c7c21/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
 github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6CZQHDETBtE9HaSEkGmuNXF86RwHhHUvq4=
@@ -305,11 +320,13 @@ github.com/vmihailenco/msgpack/v5 v5.0.0-beta.9/go.mod h1:HVxBVPUK/+fZMonk4bi1is
 github.com/vmihailenco/tagparser v0.1.2/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/wsddn/go-ecdh v0.0.0-20161211032359-48726bab9208/go.mod h1:IotVbo4F+mw0EzQ08zFqg7pK3FebNXpaMsRy2RT+Ees=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
 golang.org/x/crypto v0.0.0-20170930174604-9419663f5a44/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200115085410-6d4e4cb37c7d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -344,6 +361,7 @@ golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAG
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -357,6 +375,7 @@ golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -389,7 +408,9 @@ google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
+google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
+google.golang.org/grpc v1.32.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/internal/e2etest/README.md
+++ b/internal/e2etest/README.md
@@ -1,0 +1,17 @@
+# dcrros End-to-End Test Suite
+
+This test suite aims to setup a sample Decred simnet chain exercising most of
+of the actual observable effects of the mainnet chain, create a set of
+dcrros instances and perform the rosetta-cli `check:data` and
+`check:construction` set of tests.
+
+It requires compatible versions of `dcrd`, `dcrwallet`, `dcrros` and
+`rosetta-cli` to be installed in the environment.
+
+## Usage
+
+```shell
+$ cd internal/e2etest
+go run .
+```
+

--- a/internal/e2etest/dcrd.go
+++ b/internal/e2etest/dcrd.go
@@ -1,0 +1,226 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/dcrutil/v3"
+	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v2"
+	"github.com/decred/dcrd/rpcclient/v6"
+	"github.com/decred/dcrd/rpctest"
+)
+
+type dcrdProc struct {
+	c *rpcclient.Client
+}
+
+func (d *dcrdProc) waitTxInMempool(ctx context.Context, txh string) error {
+	for i := 0; i < 10; i++ {
+		mempool, err := d.c.GetRawMempool(ctx, chainjson.GRMAll)
+		if err != nil {
+			return err
+		}
+		for _, memtx := range mempool {
+			if memtx.String() == txh {
+				err = d.c.RegenTemplate(ctx)
+				if err != nil {
+					return err
+				}
+
+				return nil
+			}
+		}
+		time.Sleep(time.Second)
+	}
+
+	return fmt.Errorf("tx %s not found in mempool", txh)
+}
+
+func (d *dcrdProc) mine(ctx context.Context, nb uint32) ([]*chainhash.Hash, error) {
+	blocks := make([]*chainhash.Hash, nb)
+	for i := uint32(0); i < nb; i++ {
+		bl, err := rpctest.AdjustedSimnetMiner(ctx, d.c, 1)
+		if err != nil {
+			return nil, err
+		}
+
+		blocks = append(blocks, bl[0])
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	return blocks, nil
+}
+
+func (d *dcrdProc) treasuryBalance(ctx context.Context) (dcrutil.Amount, error) {
+	res, err := d.c.GetTreasuryBalance(ctx, nil, true)
+	if err != nil {
+		return 0, err
+	}
+
+	balance := dcrutil.Amount(res.Balance)
+
+	// Now, sum up all treasury bases that happened in the last
+	// CoinbaseMaturity blocks, since dcrros does not keep track of
+	// maturing balances.
+	height := res.Height
+	for i := 0; i <= int(chainParams.CoinbaseMaturity); i++ {
+		for _, up := range res.Updates {
+			balance += dcrutil.Amount(up)
+		}
+
+		height = height - 1
+		hash, err := d.c.GetBlockHash(ctx, height)
+		if err != nil {
+			return 0, err
+		}
+
+		res, err = d.c.GetTreasuryBalance(ctx, hash, true)
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	return balance, nil
+}
+
+func (dcrd *dcrdProc) nbLiveTickets(ctx context.Context) (int, error) {
+	liveTickets, err := dcrd.c.LiveTickets(ctx)
+	return len(liveTickets), err
+}
+
+func runMainMiner(ctx context.Context, wg *sync.WaitGroup, rootAppData string) (*dcrdProc, error) {
+	rosPipeRx, dcrPipeTx, err := os.Pipe()
+	if err != nil {
+		return nil, fmt.Errorf("unable to create dcrd ipc pipes: %v", err)
+	}
+
+	args := []string{
+		"--simnet",
+		"--appdata=" + filepath.Join(rootAppData, "main-dcrd"),
+		"--rpcuser=USER",
+		"--rpcpass=PASSWORD",
+		"--listen=127.0.0.1:19555",
+		"--rpclisten=127.0.0.1:19556",
+		"--nobanning",
+		"--pipetx=3",
+		"--debuglevel=debug",
+		"--lifetimeevents",
+		"--miningaddr=Sse143dKKXu6LQm5TNfpjcAYBbuuLQ3DKCj",
+		"--norelaypriority",
+		"--minrelaytxfee=0.0000001",
+		"--txindex",
+	}
+
+	dcrdOutputFile, err := os.Create(filepath.Join(rootAppData, "main-dcrd.log"))
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := exec.Command("dcrd", args...)
+	cmd.ExtraFiles = []*os.File{dcrPipeTx}
+	cmd.Stdout = dcrdOutputFile
+	cmd.Stderr = dcrdOutputFile
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	// Create the goroutine that watches over the dcrd process.
+	dcrdWaitChan := make(chan error)
+	go func() {
+		dcrdWaitChan <- cmd.Wait()
+	}()
+	wg.Add(1)
+	go func() {
+		<-ctx.Done()
+		cmd.Process.Signal(os.Interrupt)
+	}()
+
+	// Channel that will be signalled when dcrd's startup is done.
+	dcrdStartupDoneChan := make(chan struct{})
+
+	// Drain our end of the IPC pipe and close the signalling chan
+	// if we receive an appropriate event.
+	go func() {
+		event := make([]byte, 1+1+13+4+2)
+		for !shutdownRequested(ctx) {
+			// The IPC facility is really simple and we've
+			// only enabled lifetimevents so do a simple
+			// reading instead of a full-blown message
+			// parsing.
+			n, err := rosPipeRx.Read(event)
+			if err != nil {
+				log.Errorf("Failed to read dcrd IPC pipe: %v", err)
+				return
+			}
+			if n != len(event) {
+				continue
+			}
+			if string(event[2:15]) != "lifetimeevent" {
+				continue
+			}
+			if event[19] == 1 && event[20] == 0 {
+				close(dcrdStartupDoneChan)
+				return
+			}
+		}
+	}()
+
+	// Wait for the startup done chan to be signalled or a
+	// shutdown.
+	select {
+	case <-ctx.Done():
+		return nil, fmt.Errorf("dcrd never signalled startup done")
+	case errWait := <-dcrdWaitChan:
+		return nil, fmt.Errorf("dcrd errored while waiting: %v", errWait)
+	case <-dcrdStartupDoneChan:
+		log.Debugf("dcrd startup signal received")
+		// Startup can now proceed.
+	}
+
+	go func() {
+		err := <-dcrdWaitChan
+		switch {
+		case err != nil:
+			log.Warnf("Main dcrd process finished with error: %v", err)
+		default:
+			log.Debugf("Main dcrd process finished")
+		}
+		dcrdOutputFile.Close()
+		wg.Done()
+	}()
+
+	cert, err := ioutil.ReadFile(filepath.Join(rootAppData, "main-dcrd", "rpc.cert"))
+	if err != nil {
+		return nil, err
+	}
+	connCfg := &rpcclient.ConnConfig{
+		Host:         "127.0.0.1:19556",
+		Endpoint:     "ws",
+		User:         "USER",
+		Pass:         "PASSWORD",
+		Certificates: cert,
+	}
+	client, err := rpcclient.New(connCfg, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Generate enough blocks to get to Stake Enable Height.
+	if _, err := rpctest.AdjustedSimnetMiner(ctx, client, 33); err != nil {
+		return nil, err
+	}
+
+	dcrd := &dcrdProc{c: client}
+	return dcrd, nil
+}

--- a/internal/e2etest/dcrros.go
+++ b/internal/e2etest/dcrros.go
@@ -1,0 +1,225 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"time"
+
+	"decred.org/dcrros/types"
+	"github.com/coinbase/rosetta-sdk-go/client"
+	rtypes "github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/decred/dcrd/dcrutil/v3"
+)
+
+type dcrrosProc struct {
+	network *rtypes.NetworkIdentifier
+	c       *client.APIClient
+}
+
+// isUnsynced returna nil caso essa instancia do dcrros ainda esteja no bloco
+// genesis.
+func (dcrros *dcrrosProc) isUnsynced(ctx context.Context) error {
+	req := &rtypes.NetworkRequest{
+		NetworkIdentifier: dcrros.network,
+	}
+	status, rosettaErr, err := dcrros.c.NetworkAPI.NetworkStatus(ctx, req)
+	if err != nil {
+		return err
+	}
+	if rosettaErr != nil {
+		return types.RErrorAsError(rosettaErr)
+	}
+
+	curBlock := status.CurrentBlockIdentifier
+	if curBlock.Hash == chainParams.GenesisHash.String() {
+		return nil
+	}
+
+	return fmt.Errorf("dcrros not at genesis")
+}
+
+func (dcrros *dcrrosProc) waitSynced(ctx context.Context, miner *dcrdProc) error {
+	done := func() bool {
+		select {
+		case <-ctx.Done():
+			return true
+		default:
+			return false
+		}
+	}
+
+	for !done() {
+		req := &rtypes.NetworkRequest{
+			NetworkIdentifier: dcrros.network,
+		}
+		status, rosettaErr, err := dcrros.c.NetworkAPI.NetworkStatus(ctx, req)
+		if err != nil {
+			return err
+		}
+		if rosettaErr != nil {
+			return types.RErrorAsError(rosettaErr)
+		}
+
+		bestBlockHash, bestHeight, err := miner.c.GetBestBlock(ctx)
+		if err != nil {
+			return err
+		}
+
+		curBlock := status.CurrentBlockIdentifier
+		if curBlock.Hash == bestBlockHash.String() {
+			return nil
+		}
+		log.Debugf("Waiting for dcrros sync (target height %d "+
+			"target hash %s, current height %d current hash %s)",
+			bestHeight, bestBlockHash, curBlock.Index, curBlock.Hash)
+	}
+
+	return fmt.Errorf("dcrros not synced ")
+}
+
+func (dcrros *dcrrosProc) addrBalance(ctx context.Context, addr string) (dcrutil.Amount, error) {
+	req := &rtypes.AccountBalanceRequest{
+		NetworkIdentifier: dcrros.network,
+		AccountIdentifier: &rtypes.AccountIdentifier{
+			Address: addr,
+			Metadata: map[string]interface{}{
+				"script_version": uint8(0),
+			},
+		},
+	}
+	res, rosettaErr, err := dcrros.c.AccountAPI.AccountBalance(ctx, req)
+	if err != nil {
+		return 0, err
+	}
+	if rosettaErr != nil {
+		return 0, types.RErrorAsError(rosettaErr)
+	}
+	if len(res.Balances) != 1 {
+		return 0, fmt.Errorf("no balances returned")
+	}
+	balance, err := strconv.ParseInt(res.Balances[0].Value, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	return dcrutil.Amount(balance), nil
+}
+
+func runDcrros(ctx context.Context, wg *sync.WaitGroup, rootAppData string, connectToMiner bool) (*dcrrosProc, error) {
+	listenPort := 20100
+	dcrdP2pPort := 20101
+	dcrdRpcPort := 20102
+	name := "dcrros-online"
+	if !connectToMiner {
+		listenPort += 3
+		dcrdP2pPort += 3
+		dcrdRpcPort += 3
+		name = "dcrros-offline"
+	}
+
+	genRosettaCLICfg(rootAppData)
+	rootDcrros := filepath.Join(rootAppData, name)
+	rootDcrd := filepath.Join(rootDcrros, "dcrd")
+	args := []string{
+		"--simnet",
+		"--dbtype=" + *dbType,
+		"--appdata=" + rootDcrros,
+		fmt.Sprintf("--listen=127.0.0.1:%d", listenPort),
+		"--dcrdcertpath=" + filepath.Join(rootDcrd, "rpc.cert"),
+		"--rundcrd=dcrd",
+		"--dcrduser=USER",
+		"--dcrdpass=PASSWORD",
+		fmt.Sprintf("--dcrdconnect=127.0.0.1:%d", dcrdRpcPort),
+		"--dcrdextraarg=\"--appdata=" + rootDcrd + "\"",
+		fmt.Sprintf("--dcrdextraarg=\"--listen=127.0.0.1:%d\"", dcrdP2pPort),
+	}
+
+	if connectToMiner {
+		args = append(args, "--dcrdextraarg=\"--connect=127.0.0.1:19555\"")
+	}
+
+	dcrrosOutputFile, err := os.Create(filepath.Join(rootAppData, name+".log"))
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := exec.CommandContext(ctx, "dcrros", args...)
+	cmd.Stdout = dcrrosOutputFile
+	cmd.Stderr = dcrrosOutputFile
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	wg.Add(1)
+	go func() {
+		<-ctx.Done()
+		cmd.Process.Signal(os.Interrupt)
+		cmd.Wait()
+		wg.Done()
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Connect to the dcrros instance.
+	clientCfg := client.NewConfiguration(
+		fmt.Sprintf("http://127.0.0.1:%d", listenPort),
+		"e2etesting",
+		&http.Client{
+			Timeout: 10 * time.Second,
+		},
+	)
+
+	var (
+		c *client.APIClient
+	)
+
+	network := &rtypes.NetworkIdentifier{
+		Blockchain: "decred",
+		Network:    chainParams.Name,
+	}
+
+	// Try to connect for up to 10 seconds.
+	for i := 0; i < 10; i++ {
+		time.Sleep(time.Second)
+
+		c = client.NewAPIClient(clientCfg)
+
+		// Assert it's in the correct network.
+		var networkList *rtypes.NetworkListResponse
+		var rosettaErr *rtypes.Error
+		networkList, rosettaErr, err = c.NetworkAPI.NetworkList(
+			ctx,
+			&rtypes.MetadataRequest{},
+		)
+		if rosettaErr != nil && err != nil {
+			err = types.RErrorAsError(rosettaErr)
+		}
+		if err != nil {
+			continue
+		}
+
+		if len(networkList.NetworkIdentifiers) == 0 {
+			return nil, fmt.Errorf("no networks specified")
+		}
+
+		gotNet := networkList.NetworkIdentifiers[0].Network
+		if gotNet != chainParams.Name {
+			return nil, fmt.Errorf("dcrros not on %s network (got %s)",
+				chainParams.Name, gotNet)
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return &dcrrosProc{c: c, network: network}, nil
+}

--- a/internal/e2etest/dcrw.go
+++ b/internal/e2etest/dcrw.go
@@ -1,0 +1,302 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"time"
+
+	dcrwrpcclient "decred.org/dcrwallet/rpc/client/dcrwallet"
+	"github.com/decred/dcrd/dcrutil/v3"
+	"github.com/jrick/wsrpc/v2"
+)
+
+type dcrwProc struct {
+	c *dcrwrpcclient.Client
+}
+
+func (dcrw *dcrwProc) sendToAddr(ctx context.Context, addr dcrutil.Address, amount dcrutil.Amount) error {
+	_, err := dcrw.c.SendToAddress(ctx, addr, amount)
+	return err
+}
+
+func (dcrw *dcrwProc) importPrivKey(ctx context.Context, wif string) error {
+	w, err := dcrutil.DecodeWIF(wif, chainParams.PrivateKeyID)
+	if err != nil {
+		return err
+	}
+	return dcrw.c.ImportPrivKey(ctx, w)
+}
+
+func (dcrw *dcrwProc) rescanWallet(ctx context.Context) error {
+	return dcrw.c.Call(ctx, "rescanwallet", nil)
+}
+
+func (dcrw *dcrwProc) nbUtxos(ctx context.Context) (int, error) {
+	utxos, err := dcrw.c.ListUnspentMin(ctx, 1)
+	if err != nil {
+		return 0, err
+	}
+	var spendable int
+	for _, utxo := range utxos {
+		if !utxo.Spendable {
+			continue
+		}
+		if utxo.TxType == 1 {
+			continue
+		}
+		spendable++
+	}
+
+	return spendable, nil
+}
+
+func (dcrw *dcrwProc) logSpendableUtxos(ctx context.Context) {
+	nb, err := dcrw.nbUtxos(ctx)
+	if err != nil {
+		return
+	}
+	log.Debugf("Wallet has %d spendable utxos", nb)
+
+}
+
+func (dcrw *dcrwProc) waitSynced(ctx context.Context, miner *dcrdProc) error {
+	_, tipHeight, err := miner.c.GetBestBlock(ctx)
+	if err != nil {
+		return err
+	}
+
+	for i := 0; i < 20; i++ {
+		info, err := dcrw.c.GetInfo(ctx)
+		if err != nil {
+			return err
+		}
+		if int64(info.Blocks) >= tipHeight {
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	return fmt.Errorf("wallet still unsynced after timeout")
+}
+
+func (dcrw *dcrwProc) selfTransferMany(ctx context.Context, nb int) error {
+	addrs := make(map[dcrutil.Address]dcrutil.Amount, 5)
+	for j := 0; j < nb; j++ {
+		addr, err := dcrw.c.GetNewAddress(ctx, "default")
+		if err != nil {
+			return err
+		}
+		addrs[addr] = 2e8
+	}
+
+	_, err := dcrw.c.SendMany(ctx, "default", addrs)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (dcrw *dcrwProc) genManyUtxos(ctx context.Context, miner *dcrdProc) error {
+	// Generate some initial utxos.
+	if err := dcrw.waitSynced(ctx, miner); err != nil {
+		return err
+	}
+	dcrw.logSpendableUtxos(ctx)
+	if _, err := miner.mine(ctx, 10); err != nil {
+		return err
+	}
+	if err := dcrw.waitSynced(ctx, miner); err != nil {
+		return err
+	}
+	dcrw.logSpendableUtxos(ctx)
+
+	// From those, self-transfer to many different addresses.
+	for i := 0; i < 15; i++ {
+		if err := dcrw.selfTransferMany(ctx, i+1); err != nil {
+			return err
+		}
+		time.Sleep(100 * time.Millisecond)
+
+		if _, err := miner.mine(ctx, 1); err != nil {
+			return err
+		}
+	}
+
+	dcrw.logSpendableUtxos(ctx)
+
+	return nil
+}
+
+func (dcrw *dcrwProc) fillTicketPool(ctx context.Context, miner *dcrdProc) error {
+	for {
+		liveTickets, err := miner.c.LiveTickets(ctx)
+		if err != nil {
+			return err
+		}
+
+		if len(liveTickets) > 64 {
+			log.Debugf("Filled ticket pool with %d tickets", len(liveTickets))
+			return nil
+		}
+
+		nbTickets := 10
+		_, err = dcrw.c.PurchaseTicket(ctx, "default", 100e8, nil, nonVotingAddr, &nbTickets,
+			nil, nil, nil, nil, nil)
+		if err != nil {
+			return err
+		}
+
+		if _, err := miner.mine(ctx, 1); err != nil {
+			return err
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+func runMainWallet(ctx context.Context, wg *sync.WaitGroup, rootAppData string) (*dcrwProc, error) {
+	args := []string{
+		"--simnet",
+		"--appdata=" + filepath.Join(rootAppData, "main-dcrw"),
+		"--username=USER",
+		"--password=PASSWORD",
+		"--nogrpc",
+		"--rpclisten=127.0.0.1:19557",
+		"--pass=123",
+		"--enablevoting",
+		//	"--enableticketbuyer",
+		//"--ticketbuyer.limit=5",
+		"--cafile=" + filepath.Join(rootAppData, "main-dcrd", "rpc.cert"),
+	}
+
+	dcrwOutputFile, err := os.Create(filepath.Join(rootAppData, "main-dcrw.log"))
+	if err != nil {
+		return nil, err
+	}
+
+	createWalletPipeRx, createWalletPipeTx, err := os.Pipe()
+	if err != nil {
+		return nil, fmt.Errorf("unable to create dcrw pipes: %v", err)
+	}
+
+	// Create the wallet.
+	args = append(args, "--create")
+
+	cmd := exec.CommandContext(ctx, "dcrwallet", args...)
+	cmd.Stdout = dcrwOutputFile
+	cmd.Stderr = dcrwOutputFile
+	cmd.Stdin = createWalletPipeRx
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	walletWrite := func(s string) {
+		b := []byte(s)
+		var n int
+		var err error
+		for n, err = createWalletPipeTx.Write(b); n < len(b) && err != nil; {
+			b = b[n:]
+		}
+		if err != nil {
+			panic(err)
+		}
+	}
+	walletWrite("y\n")                              // Use pass from config.
+	walletWrite("n\n")                              // No additional encryption.
+	walletWrite("y\n")                              // Have seed.
+	walletWrite("00000000000000000000000000000000") // Seed.
+	walletWrite("00000000000000000000000000000000\n\n")
+
+	// Wait for the wallet to end.
+	createWalletWait := make(chan error)
+	go func() {
+		createWalletWait <- cmd.Wait()
+	}()
+	select {
+	case err := <-createWalletWait:
+		if err != nil {
+			return nil, err
+		}
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+
+	// Drop --create from the args.
+	args = args[:len(args)-1]
+
+	// Start the wallet again.
+	cmd = exec.Command("dcrwallet", args...)
+	cmd.Stdout = dcrwOutputFile
+	cmd.Stderr = dcrwOutputFile
+	cmd.Stdin = createWalletPipeRx
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	// Command the wallet to stop once the context is done.
+	go func() {
+		<-ctx.Done()
+		cmd.Process.Signal(os.Interrupt)
+	}()
+
+	// Monitor for the wallet to finish.
+	wg.Add(1)
+	go func() {
+		err := cmd.Wait()
+		switch {
+		case err != nil:
+			log.Warnf("Main wallet process finished with error: %v", err)
+		default:
+			log.Debugf("Main wallet process finished")
+		}
+		wg.Done()
+	}()
+
+	// Wait for it to startup and get synced.
+	time.Sleep(time.Millisecond * 100)
+
+	// Connect to the wallet.
+	cert, err := ioutil.ReadFile(filepath.Join(rootAppData, "main-dcrw", "rpc.cert"))
+	if err != nil {
+		return nil, err
+	}
+
+	opts := make([]wsrpc.Option, 0, 5)
+	opts = append(opts, wsrpc.WithBasicAuth("USER", "PASSWORD"))
+	opts = append(opts, wsrpc.WithoutPongDeadline())
+	pool := x509.NewCertPool()
+	pool.AppendCertsFromPEM(cert)
+	tc := &tls.Config{
+		MinVersion:       tls.VersionTLS12,
+		CurvePreferences: []tls.CurveID{tls.X25519, tls.CurveP256},
+		CipherSuites: []uint16{ // Only applies to TLS 1.2. TLS 1.3 ciphersuites are not configurable.
+			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		},
+		RootCAs: pool,
+	}
+	opts = append(opts, wsrpc.WithTLSConfig(tc))
+	client, err := wsrpc.Dial(ctx, "wss://127.0.0.1:19557/ws", opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	c := dcrwrpcclient.NewClient(client, chainParams)
+
+	return &dcrwProc{c: c}, nil
+}

--- a/internal/e2etest/log.go
+++ b/internal/e2etest/log.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/decred/slog"
+	"github.com/jrick/logrotate/rotator"
+)
+
+// logWriter implements an io.Writer that outputs to both standard output and
+// the write-end pipe of an initialized log rotator.
+type logWriter struct{}
+
+func (logWriter) Write(p []byte) (n int, err error) {
+	os.Stdout.Write(p)
+	logRotator.Write(p)
+	return len(p), nil
+}
+
+// Loggers per subsystem.  A single backend logger is created and all subsytem
+// loggers created from it will write to the backend.  When adding new
+// subsystems, add the subsystem logger variable here and to the
+// subsystemLoggers map.
+//
+// Loggers can not be used before the log rotator has been initialized with a
+// log file.  This must be performed early during application startup by calling
+// initLogRotator.
+var (
+	// backendLog is the logging backend used to create all subsystem
+	// loggers.  The backend must not be used before the log rotator has
+	// been initialized, or data races and/or nil pointer dereferences will
+	// occur.
+	backendLog = slog.NewBackend(logWriter{})
+
+	// logRotator is one of the logging outputs.  It should be closed on
+	// application shutdown.
+	logRotator *rotator.Rotator
+
+	log = backendLog.Logger("E2ET")
+)
+
+// Initialize package-global logger variables.
+func init() {
+}
+
+// subsystemLoggers maps each subsystem identifier to its associated logger.
+var subsystemLoggers = map[string]slog.Logger{
+	"E2ET": log,
+}
+
+// initLogRotator initializes the logging rotater to write logs to logFile and
+// create roll files in the same directory.  It must be called before the
+// package-global log rotater variables are used.
+func initLogRotator(logFile string) {
+	logDir, _ := filepath.Split(logFile)
+	err := os.MkdirAll(logDir, 0700)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create log directory: %v\n", err)
+		os.Exit(1)
+	}
+	r, err := rotator.New(logFile, 10*1024*1024, false, 3)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create file rotator: %v\n", err)
+		os.Exit(1)
+	}
+
+	logRotator = r
+}
+
+// setLogLevel sets the logging level for provided subsystem.  Invalid
+// subsystems are ignored.  Uninitialized subsystems are dynamically created as
+// needed.
+func setLogLevel(subsystemID string, logLevel string) {
+	// Ignore invalid subsystems.
+	logger, ok := subsystemLoggers[subsystemID]
+	if !ok {
+		return
+	}
+
+	// Defaults to info if the log level is invalid.
+	level, _ := slog.LevelFromString(logLevel)
+	logger.SetLevel(level)
+}
+
+// setLogLevels sets the log level for all subsystem loggers to the passed
+// level.  It also dynamically creates the subsystem loggers as needed, so it
+// can be used to initialize the logging system.
+func setLogLevels(logLevel string) {
+	// Configure all sub-systems with the new logging level.  Dynamically
+	// create loggers as needed.
+	for subsystemID := range subsystemLoggers {
+		setLogLevel(subsystemID, logLevel)
+	}
+}

--- a/internal/e2etest/main.go
+++ b/internal/e2etest/main.go
@@ -1,0 +1,164 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/decred/dcrd/chaincfg/v3"
+	"github.com/decred/dcrd/dcrutil/v3"
+)
+
+var (
+	chainParams      = chaincfg.SimNetParams()
+	prefundAddr, _   = dcrutil.DecodeAddress("SsaJzoa8kcRQEuoy3L4oV65YiioNmDuvdVk", chainParams)
+	prefundAmt       = dcrutil.Amount(100000000)
+	nonVotingPrivKey = "PsUS3CSq9iJkRi4GqHF8MttgPCTgTZda8ZLMqa3PCe2n7bV4pfK4a"
+	nonVotingAddr, _ = dcrutil.DecodeAddress("Ssiyo3v8KKDr7zJhi7VBFcrZMh49VarKVLd", chainParams)
+	targetAddr, _    = dcrutil.DecodeAddress("SsXiPL51iPAzsxfY84YEs1tQMoo9kfiCj5o", chainParams)
+
+	debugLevel = flag.String("debuglevel", "info", "logging level. Most common: warn,info,debug")
+	appData    = flag.String("appdata", "", "path for root data dir. Use a temp one if empty")
+	dbType     = flag.String("dbtype", "mem", "dbtype to use for dcrros tests")
+)
+
+func _main() error {
+	flag.Parse()
+	wg := new(sync.WaitGroup)
+	ctx := shutdownListener()
+
+	// Ensure we shut everything down if we exit early and wait for all
+	// goroutines to end.
+	defer func() {
+		if !shutdownRequested(ctx) {
+			requestShutdown()
+		}
+		wg.Wait()
+	}()
+
+	// Defer a maximum execution time of 10 minutes.
+	go func() {
+		select {
+		case <-time.After(10 * time.Minute):
+			log.Errorf("Test timed out. Cancelling.")
+			requestShutdown()
+		case <-ctx.Done():
+		}
+	}()
+
+	dcrdVers, dcrwVers, dcrrosVers, roscliVers, err := procVersions()
+	if err != nil {
+		return fmt.Errorf("Unable to fetch exe versions: %v", err)
+	}
+
+	// App setup.
+	rootAppData := *appData
+	rootIsTempDir := false
+	if rootAppData == "" {
+		var err error
+		rootAppData, err = ioutil.TempDir("", "dcrros-e2e-")
+		if err != nil {
+			return err
+		}
+		rootIsTempDir = true
+	}
+	if err := cleanRootAppData(rootAppData); err != nil {
+		return err
+	}
+	initLogRotator(filepath.Join(rootAppData, "e2e.log"))
+	setLogLevels(*debugLevel)
+	if rootIsTempDir {
+		log.Infof("App data in temp dir: %s", rootAppData)
+	}
+	log.Infof("Using dbtype %s", *dbType)
+	log.Infof("dcrd version: %s", dcrdVers)
+	log.Infof("dcrwallet version: %s", dcrwVers)
+	log.Infof("dcrros version: %s", dcrrosVers)
+	log.Infof("rosetta-cli version: %s", roscliVers)
+
+	// Run the main dcrd miner.
+	log.Infof("Running main dcrd miner")
+	miner, err := runMainMiner(ctx, wg, rootAppData)
+	if err != nil {
+		return fmt.Errorf("Error while running main miner: %v", err)
+	}
+
+	// Run the main wallet.
+	log.Infof("Running main wallet")
+	wallet, err := runMainWallet(ctx, wg, rootAppData)
+	if err != nil {
+		return fmt.Errorf("Error while running main wallet: %v", err)
+	}
+
+	// Generate test chain.
+	log.Infof("Generating test chain")
+	if err := genTestChain(ctx, miner, wallet); err != nil {
+		return fmt.Errorf("Error while generating test chain: %v", err)
+	}
+
+	// Run the dcrros instance that is connected to the network ("online").
+	log.Infof("Running online dcrros")
+	dcrrosOnline, err := runDcrros(ctx, wg, rootAppData, true)
+	if err != nil {
+		return fmt.Errorf("Error while running online dcrros: %v", err)
+	}
+
+	// Run the dcrros instance that is *not* connected to the network
+	// ("offline").
+	log.Infof("Running offline dcrros")
+	dcrrosOffline, err := runDcrros(ctx, wg, rootAppData, false)
+	if err != nil {
+		return fmt.Errorf("Error while running offline dcrros: %v", err)
+	}
+
+	// Wait until the online dcrros is synced to the network and ensure the
+	// offline is unsynced.
+	log.Infof("Waiting for online dcrros to sync to miner")
+	if err := dcrrosOnline.waitSynced(ctx, miner); err != nil {
+		return fmt.Errorf("Error while waiting for online dcrros to sync: %v", err)
+	}
+	log.Debugf("Online dcrros instance synced")
+	if err := dcrrosOffline.isUnsynced(ctx); err != nil {
+		return fmt.Errorf("Error while checking offline dcrros is unsynced: %v", err)
+	}
+	log.Debugf("Offline dcrros instance still at genesis")
+
+	// Perform some sanity checks on the online dcrros instance.
+	log.Infof("Performing spot checks in online dcrros instance")
+	if err := checkTestChain(ctx, dcrrosOnline, miner, wallet); err != nil {
+		return fmt.Errorf("Error checking dcrros against test chain: %v", err)
+	}
+
+	// Perform the rosetta-cli check:data suite of tests.
+	log.Infof("Running check data")
+	if err := runRosettaCLICheckData(ctx, rootAppData); err != nil {
+		return fmt.Errorf("Error while running rosetta-cli check-data: %v", err)
+	}
+
+	// Perform the rosetta-cli check:construction suite of tests.
+	log.Infof("Running check construction")
+	if err := runRosettaCLICheckConstruction(ctx, rootAppData, miner, wallet); err != nil {
+		return fmt.Errorf("Error while running rosetta-cli check:construction: %v", err)
+	}
+
+	// Woot!
+	return nil
+}
+
+func main() {
+	startTime := time.Now()
+	if err := _main(); err != nil {
+		log.Error(err.Error())
+		os.Exit(1)
+	} else {
+		log.Infof("Success! Test took %s", time.Since(startTime).Truncate(100*time.Millisecond))
+	}
+}

--- a/internal/e2etest/processes.go
+++ b/internal/e2etest/processes.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// cleanRootAppData creates and cleans the root data dir for an 2e2 test run.
+func cleanRootAppData(rootAppData string) error {
+	if _, err := os.Stat(rootAppData); os.IsNotExist(err) {
+		err := os.MkdirAll(rootAppData, os.ModePerm)
+		if err != nil {
+			return err
+		}
+	}
+	paths := []string{
+		"main-dcrd",
+		"main-dcrd.log",
+		"main-dcrw",
+		"main-dcrw.log",
+		"dcrros-online",
+		"dcrros-online.log",
+		"dcrros-offline",
+		"dcrros-offline.log",
+		"rosetta-cli-data",
+		"rosetta-cli.json",
+		"check-data.log",
+		"check-construction.log",
+	}
+	for _, path := range paths {
+		err := os.RemoveAll(filepath.Join(rootAppData, path))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getProcVersion(exe, arg string) (string, error) {
+	cmd := exec.Command(exe, arg)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func procVersions() (dcrd string, dcrw string, dcrros string, roscli string, err error) {
+	if dcrd, err = getProcVersion("dcrd", "--version"); err != nil {
+		return
+	}
+	if dcrw, err = getProcVersion("dcrwallet", "--version"); err != nil {
+		return
+	}
+	if dcrros, err = getProcVersion("dcrros", "--version"); err != nil {
+		return
+	}
+	if roscli, err = getProcVersion("rosetta-cli", "version"); err != nil {
+		return
+	}
+
+	return
+}

--- a/internal/e2etest/rosettacli.go
+++ b/internal/e2etest/rosettacli.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+func runRosettaCLICheckData(ctx context.Context, rootAppData string) error {
+	cliOutputFile, err := os.Create(filepath.Join(rootAppData, "check-data.log"))
+	if err != nil {
+		return err
+	}
+
+	args := []string{
+		"--configuration-file=" + filepath.Join(rootAppData, "rosetta-cli.json"),
+		"check:data",
+	}
+	cmd := exec.CommandContext(ctx, "rosetta-cli", args...)
+	cmd.Stdout = cliOutputFile
+	cmd.Stderr = cliOutputFile
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	waitCheckData := make(chan error)
+	go func() {
+		waitCheckData <- cmd.Wait()
+	}()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case err := <-waitCheckData:
+		return err
+	}
+}
+
+func runRosettaCLICheckConstruction(ctx context.Context, rootAppData string,
+	miner *dcrdProc, wallet *dcrwProc) error {
+
+	cliOutputFile, err := os.Create(filepath.Join(rootAppData, "check-construction.log"))
+	if err != nil {
+		return err
+	}
+
+	args := []string{
+		"--configuration-file=" + filepath.Join(rootAppData, "rosetta-cli.json"),
+		"check:construction",
+	}
+	cmd := exec.CommandContext(ctx, "rosetta-cli", args...)
+	cmd.Stdout = cliOutputFile
+	cmd.Stderr = cliOutputFile
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	// How many outputs to send to the prefund address for
+	// check:construction to do its tests.
+	nbOutputs := 5
+
+	// Start slow mining blocks, which is needed for the check:construction
+	// tests.
+	constructionDone := make(chan struct{})
+	defer func() { close(constructionDone) }()
+	go func() {
+		time.Sleep(time.Millisecond * 100)
+
+		// Create the necessary outputs in the prefunded account.
+		for i := 0; i < nbOutputs; i++ {
+			if err := wallet.sendToAddr(ctx, prefundAddr, prefundAmt); err != nil {
+				log.Errorf("Error while prefunding construction addr: %v", err)
+			}
+		}
+
+		// Slow mine so check:construction will build, broadcast and
+		// verify the txs were mined.
+		for {
+			start := time.Now()
+			err := mineAndSyncWallet(ctx, miner, wallet, 1)
+			if err != nil && !errors.Is(err, context.Canceled) {
+				log.Errorf("Error while trying to mine in "+
+					"check:construction: %v", err)
+			}
+
+			sleepAmt := time.Second - time.Since(start)
+			if sleepAmt <= 0 {
+				continue
+			}
+
+			select {
+			case <-constructionDone:
+				return
+			case <-time.After(time.Second):
+			}
+		}
+	}()
+
+	waitCheckConstruction := make(chan error)
+	go func() {
+		waitCheckConstruction <- cmd.Wait()
+	}()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case err := <-waitCheckConstruction:
+		return err
+	}
+}

--- a/internal/e2etest/rosettacli_cfg.go
+++ b/internal/e2etest/rosettacli_cfg.go
@@ -1,0 +1,419 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+func genRosettaCLICfg(rootAppData string) error {
+	dataDir := filepath.Join(rootAppData, "rosetta-cli-data")
+	data := `
+{
+  "network": {
+    "blockchain": "decred",
+    "network": "simnet"
+  },
+  "online_url": "http://127.0.0.1:20100",
+  "data_directory": "` + dataDir + `",
+  "http_timeout": 10,
+  "max_retries": 5,
+  "retry_elapsed_time": 0,
+  "max_online_connections": 120,
+  "max_sync_concurrency": 64,
+  "tip_delay": 300,
+  "log_configuration": false,
+  "data": {
+    "active_reconciliation_concurrency": 16,
+    "inactive_reconciliation_concurrency": 4,
+    "inactive_reconciliation_frequency": 250,
+    "log_blocks": false,
+    "log_transactions": false,
+    "log_balance_changes": false,
+    "log_reconciliations": false,
+    "ignore_reconciliation_error": false,
+    "exempt_accounts": "",
+    "bootstrap_balances": "",
+    "interesting_accounts": "",
+    "reconciliation_disabled": false,
+    "inactive_discrepency_search_disabled": false,
+    "balance_tracking_disabled": false,
+    "coin_tracking_disabled": false,
+    "results_output_file": "",
+    "historical_balance_enabled": true,
+    "end_conditions": {
+      "reconciliation_coverage": {
+        "coverage": 1.0,
+        "tip": true
+      }
+    }
+  },
+  "construction": {
+    "offline_url": "http://localhost:20103",
+    "max_offline_connections": 0,
+    "stale_depth": 0,
+    "broadcast_limit": 0,
+    "ignore_broadcast_failures": false,
+    "clear_broadcasts": false,
+    "broadcast_behind_tip": false,
+    "block_broadcast_limit": 0,
+    "rebroadcast_all": false,
+    "end_conditions": {
+      "create_account": 2
+    },
+    "prefunded_accounts": [{
+      "privkey": "77561fd84f7e86e68b65e868324c390e9a5246f6eb9bf8f56c14d86511316f60",
+      "account_identifier": {
+        "address": "SsaJzoa8kcRQEuoy3L4oV65YiioNmDuvdVk",
+	"metadata": {
+          "script_version": 0
+	}
+      },
+      "curve_type": "secp256k1",
+      "currency": {
+        "symbol": "DCR",
+	"decimals": 8
+      }
+    }],
+    "workflows": [
+      {
+        "name": "request_funds",
+        "concurrency": 1,
+        "scenarios": [
+          {
+            "name": "find_account",
+            "actions": [
+              {
+                "input": "{\"symbol\":\"DCR\",\"decimals\":8}",
+                "type": "set_variable",
+                "output_path": "currency"
+              },
+              {
+                "input": "{\"minimum_balance\": {\"value\": \"0\", \"currency\": {{currency}}}, \"create_limit\": 1}",
+                "type": "find_balance",
+                "output_path": "random_account"
+              }
+            ]
+          },
+          {
+            "name": "request",
+            "actions": [
+              {
+                "input": "{\"account_identifier\": {{random_account.account_identifier}}, \"minimum_balance\": {\"value\": \"100000000\", \"currency\": {{currency}}}}",
+                "type": "find_balance",
+                "output_path": "loaded_account"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "create_account",
+        "concurrency": 1,
+        "scenarios": [
+          {
+            "name": "create_account",
+            "actions": [
+              {
+                "input": "{\"network\": \"simnet\", \"blockchain\": \"decred\"}",
+                "type": "set_variable",
+                "output_path": "network"
+              },
+              {
+                "input": "{\"curve_type\": \"secp256k1\"}",
+                "type": "generate_key",
+                "output_path": "key"
+              },
+              {
+                "input": "{\"network_identifier\": {{network}}, \"public_key\": {{key.public_key}}, \"metadata\": {\"script_version\": 0}}",
+                "type": "derive",
+                "output_path": "account"
+              },
+              {
+                "input": "{\"account_identifier\": {{account.account_identifier}}, \"keypair\": {{key}}}",
+                "type": "save_account"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "transfer",
+        "concurrency": 2,
+        "scenarios": [
+          {
+            "name": "transfer_dry_run",
+            "actions": [
+              {
+                "input": "{\"network\":\"simnet\", \"blockchain\":\"decred\"}",
+                "type": "set_variable",
+                "output_path": "transfer_dry_run.network"
+              },
+              {
+                "input": "{\"symbol\":\"DCR\", \"decimals\":8}",
+                "type": "set_variable",
+                "output_path": "currency"
+              },
+              {
+                "input": "\"6030\"",
+                "type": "set_variable",
+                "output_path": "dust_amount"
+              },
+              {
+                "input": "\"2980\"",
+                "type": "set_variable",
+                "output_path": "max_fee_amount"
+              },
+              {
+                "input": "{\"operation\":\"addition\", \"left_value\": {{dust_amount}}, \"right_value\": {{max_fee_amount}}}",
+                "type": "math",
+                "output_path": "send_buffer"
+              },
+              {
+                "input": "\"24000\"",
+                "type": "set_variable",
+                "output_path": "reserved_amount"
+              },
+              {
+                "input": "{\"require_coin\":true, \"minimum_balance\":{\"value\": {{reserved_amount}}, \"currency\": {{currency}}}}",
+                "type": "find_balance",
+                "output_path": "sender"
+              },
+              {
+                "input": "{\"operation\":\"subtraction\", \"left_value\": {{sender.balance.value}}, \"right_value\": {{send_buffer}}}",
+                "type": "math",
+                "output_path": "available_amount"
+              },
+              {
+                "input": "{\"minimum\": {{dust_amount}}, \"maximum\": {{available_amount}}}",
+                "type": "random_number",
+                "output_path": "recipient_amount"
+              },
+              {
+                "input": "{\"recipient_amount\":{{recipient_amount}}}",
+                "type": "print_message"
+              },
+              {
+                "input": "{\"operation\":\"subtraction\", \"left_value\": {{sender.balance.value}}, \"right_value\": {{recipient_amount}}}",
+                "type": "math",
+                "output_path": "total_change_amount"
+              },
+              {
+                "input": "{\"operation\":\"subtraction\", \"left_value\": {{total_change_amount}}, \"right_value\": {{max_fee_amount}}}",
+                "type": "math",
+                "output_path": "change_amount"
+              },
+              {
+                "input": "{\"change_amount\":{{change_amount}}}",
+                "type": "print_message"
+              },
+              {
+                "input": "{\"operation\":\"subtraction\", \"left_value\": \"0\", \"right_value\":{{sender.balance.value}}}",
+                "type": "math",
+                "output_path": "sender_amount"
+              },
+              {
+                "input": "{\"not_account_identifier\":[{{sender.account_identifier}}], \"not_coins\":[{{sender.coin}}], \"minimum_balance\":{\"value\": \"0\", \"currency\": {{currency}}}, \"create_limit\": 100, \"create_probability\": 50}",
+                "type": "find_balance",
+                "output_path": "recipient"
+              },
+              {
+                "input": "\"1\"",
+                "type": "set_variable",
+                "output_path": "transfer_dry_run.confirmation_depth"
+              },
+              {
+                "input": "\"true\"",
+                "type": "set_variable",
+                "output_path": "transfer_dry_run.dry_run"
+              },
+              {
+                "input": "[{\"operation_identifier\":{\"index\":0},\"type\":\"debit\",\"account\":{{sender.account_identifier}},\"amount\":{\"value\":{{sender_amount}},\"currency\":{{currency}}}, \"coin_change\":{\"coin_action\":\"coin_spent\", \"coin_identifier\":{{sender.coin}}}},{\"operation_identifier\":{\"index\":1},\"type\":\"credit\",\"account\":{{recipient.account_identifier}},\"amount\":{\"value\":{{recipient_amount}},\"currency\":{{currency}}}}, {\"operation_identifier\":{\"index\":2},\"type\":\"credit\",\"account\":{{sender.account_identifier}},\"amount\":{\"value\":{{change_amount}},\"currency\":{{currency}}}}]",
+                "type": "set_variable",
+                "output_path": "transfer_dry_run.operations"
+              },
+              {
+                "input": "{{transfer_dry_run.operations}}",
+                "type": "print_message"
+              }
+            ]
+          },
+          {
+            "name": "transfer",
+            "actions": [
+              {
+                "input": "{\"currency\":{{currency}}, \"amounts\":{{transfer_dry_run.suggested_fee}}}",
+                "type": "find_currency_amount",
+                "output_path": "suggested_fee"
+              },
+              {
+                "input": "{\"operation\":\"subtraction\", \"left_value\": {{total_change_amount}}, \"right_value\": {{suggested_fee.value}}}",
+                "type": "math",
+                "output_path": "change_amount"
+              },
+              {
+                "input": "{\"operation\":\"subtraction\", \"left_value\": {{change_amount}}, \"right_value\": {{dust_amount}}}",
+                "type": "math",
+                "output_path": "change_minus_dust"
+              },
+              {
+                "input": "{{change_minus_dust}}",
+                "type": "assert"
+              },
+              {
+                "input": "{\"network\":\"simnet\", \"blockchain\":\"decred\"}",
+                "type": "set_variable",
+                "output_path": "transfer.network"
+              },
+              {
+                "input": "\"1\"",
+                "type": "set_variable",
+                "output_path": "transfer.confirmation_depth"
+              },
+              {
+                "input": "[{\"operation_identifier\":{\"index\":0},\"type\":\"debit\",\"account\":{{sender.account_identifier}},\"amount\":{\"value\":{{sender_amount}},\"currency\":{{currency}}}, \"coin_change\":{\"coin_action\":\"coin_spent\", \"coin_identifier\":{{sender.coin}}}},{\"operation_identifier\":{\"index\":1},\"type\":\"credit\",\"account\":{{recipient.account_identifier}},\"amount\":{\"value\":{{recipient_amount}},\"currency\":{{currency}}}}, {\"operation_identifier\":{\"index\":2},\"type\":\"credit\",\"account\":{{sender.account_identifier}},\"amount\":{\"value\":{{change_amount}},\"currency\":{{currency}}}}]",
+                "type": "set_variable",
+                "output_path": "transfer.operations"
+              },
+              {
+                "input": "{{transfer.operations}}",
+                "type": "print_message"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "return_funds",
+        "concurrency": 10,
+        "scenarios": [
+          {
+            "name": "transfer_dry_run",
+            "actions": [
+              {
+                "input": "{\"network\":\"simnet\", \"blockchain\":\"decred\"}",
+                "type": "set_variable",
+                "output_path": "transfer_dry_run.network"
+              },
+              {
+                "input": "{\"symbol\":\"DCR\", \"decimals\":8}",
+                "type": "set_variable",
+                "output_path": "currency"
+              },
+              {
+                "input": "\"2980\"",
+                "type": "set_variable",
+                "output_path": "max_fee_amount"
+              },
+              {
+                "input": "\"18000\"",
+                "type": "set_variable",
+                "output_path": "reserved_amount"
+              },
+              {
+                "input": "{\"require_coin\":true, \"minimum_balance\":{\"value\": {{reserved_amount}}, \"currency\": {{currency}}}}",
+                "type": "find_balance",
+                "output_path": "sender"
+              },
+              {
+                "input": "{\"operation\":\"subtraction\", \"left_value\": {{sender.balance.value}}, \"right_value\": {{max_fee_amount}}}",
+                "type": "math",
+                "output_path": "recipient_amount"
+              },
+              {
+                "input": "{\"recipient_amount\":{{recipient_amount}}}",
+                "type": "print_message"
+              },
+              {
+                "input": "{\"operation\":\"subtraction\", \"left_value\": \"0\", \"right_value\":{{sender.balance.value}}}",
+                "type": "math",
+                "output_path": "sender_amount"
+              },
+              {
+                "input": "\"1\"",
+                "type": "set_variable",
+                "output_path": "transfer_dry_run.confirmation_depth"
+              },
+              {
+                "input": "\"true\"",
+                "type": "set_variable",
+                "output_path": "transfer_dry_run.dry_run"
+              },
+              {
+                "input": "{\"address\": \"Ssp7J7TUmi5iPhoQnWYNGQbeGhu6V3otJcS\", \"metadata\":{\"script_version\": 0}}",
+                "type": "set_variable",
+                "output_path": "recipient"
+              },
+              {
+                "input": "[{\"operation_identifier\":{\"index\":0},\"type\":\"debit\",\"account\":{{sender.account_identifier}},\"amount\":{\"value\":{{sender_amount}},\"currency\":{{currency}}}, \"coin_change\":{\"coin_action\":\"coin_spent\", \"coin_identifier\":{{sender.coin}}}},{\"operation_identifier\":{\"index\":1},\"type\":\"credit\",\"account\":{{recipient}},\"amount\":{\"value\":{{recipient_amount}},\"currency\":{{currency}}}}]",
+                "type": "set_variable",
+                "output_path": "transfer_dry_run.operations"
+              },
+              {
+                "input": "{{transfer_dry_run.operations}}",
+                "type": "print_message"
+              }
+            ]
+          },
+          {
+            "name": "transfer",
+            "actions": [
+              {
+                "input": "{\"currency\":{{currency}}, \"amounts\":{{transfer_dry_run.suggested_fee}}}",
+                "type": "find_currency_amount",
+                "output_path": "suggested_fee"
+              },
+              {
+                "input": "{\"operation\":\"subtraction\", \"left_value\": {{sender.balance.value}}, \"right_value\": {{suggested_fee.value}}}",
+                "type": "math",
+                "output_path": "recipient_amount"
+              },
+              {
+                "input": "\"6030\"",
+                "type": "set_variable",
+                "output_path": "dust_amount"
+              },
+              {
+                "input": "{\"operation\":\"subtraction\", \"left_value\": {{recipient_amount}}, \"right_value\": {{dust_amount}}}",
+                "type": "math",
+                "output_path": "recipient_minus_dust"
+              },
+              {
+                "input": "{{recipient_minus_dust}}",
+                "type": "assert"
+              },
+              {
+                "input": "{\"network\":\"simnet\", \"blockchain\":\"decred\"}",
+                "type": "set_variable",
+                "output_path": "transfer.network"
+              },
+              {
+                "input": "\"1\"",
+                "type": "set_variable",
+                "output_path": "transfer.confirmation_depth"
+              },
+              {
+                "input": "[{\"operation_identifier\":{\"index\":0},\"type\":\"debit\",\"account\":{{sender.account_identifier}},\"amount\":{\"value\":{{sender_amount}},\"currency\":{{currency}}}, \"coin_change\":{\"coin_action\":\"coin_spent\", \"coin_identifier\":{{sender.coin}}}},{\"operation_identifier\":{\"index\":1},\"type\":\"credit\",\"account\":{{recipient}},\"amount\":{\"value\":{{recipient_amount}},\"currency\":{{currency}}}}]",
+                "type": "set_variable",
+                "output_path": "transfer.operations"
+              },
+              {
+                "input": "{{transfer.operations}}",
+                "type": "print_message"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}
+`
+
+	cfgFilePath := filepath.Join(rootAppData, "rosetta-cli.json")
+	return ioutil.WriteFile(cfgFilePath, []byte(data), os.ModePerm)
+}

--- a/internal/e2etest/signal.go
+++ b/internal/e2etest/signal.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2013-2016 The btcsuite developers
+// Copyright (c) 2015-2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"context"
+	"os"
+	"os/signal"
+)
+
+// shutdownRequestChannel is used to initiate shutdown from one of the
+// subsystems using the same code paths as when an interrupt signal is received.
+var shutdownRequestChannel = make(chan struct{})
+
+// interruptSignals defines the default signals to catch in order to do a proper
+// shutdown.  This may be modified during init depending on the platform.
+var interruptSignals = []os.Signal{os.Interrupt}
+
+// requestShutdown requests the process to end. It blocks until the shutdown
+// process signal is received.
+func requestShutdown() {
+	shutdownRequestChannel <- struct{}{}
+}
+
+// shutdownListener listens for OS Signals such as SIGINT (Ctrl+C) and shutdown
+// requests from shutdownRequestChannel.  It returns a context that is canceled
+// when either signal is received.
+func shutdownListener() context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		interruptChannel := make(chan os.Signal, 1)
+		signal.Notify(interruptChannel, interruptSignals...)
+
+		// Listen for initial shutdown signal and cancel the returned context.
+		select {
+		case sig := <-interruptChannel:
+			log.Infof("Received signal (%s).  Shutting down...", sig)
+
+		case <-shutdownRequestChannel:
+			log.Infof("Shutdown requested.  Shutting down...")
+		}
+		cancel()
+
+		// Listen for repeated signals and display a message so the user
+		// knows the shutdown is in progress and the process is not
+		// hung.
+		for {
+			select {
+			case sig := <-interruptChannel:
+				log.Infof("Received signal (%s).  Already "+
+					"shutting down...", sig)
+
+			case <-shutdownRequestChannel:
+				log.Info("Shutdown requested.  Already " +
+					"shutting down...")
+			}
+		}
+	}()
+
+	return ctx
+}
+
+// shutdownRequested returns true when the context returned by shutdownListener
+// was canceled.  This simplifies early shutdown slightly since the caller can
+// just use an if statement instead of a select.
+func shutdownRequested(ctx context.Context) bool {
+	select {
+	case <-ctx.Done():
+		return true
+	default:
+	}
+
+	return false
+}

--- a/internal/e2etest/testchain.go
+++ b/internal/e2etest/testchain.go
@@ -1,0 +1,568 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"decred.org/dcrros/types"
+	walletjson "decred.org/dcrwallet/rpc/jsonrpc/types"
+	"github.com/decred/dcrd/blockchain/stake/v3"
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/dcrutil/v3"
+	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v2"
+	"github.com/decred/dcrd/txscript/v3"
+	"github.com/decred/dcrd/wire"
+)
+
+func sendToTreasury(ctx context.Context, wallet *dcrwProc, amt dcrutil.Amount) (string, error) {
+	var res string
+	err := wallet.c.Call(ctx, "sendtotreasury", &res, float64(amt)/1e8)
+	log.Debugf("TAdd generated: %s", res)
+	return res, err
+}
+
+func sendFromTreasury(ctx context.Context, wallet *dcrwProc, addr string, amt dcrutil.Amount) (string, error) {
+	var res string
+	key := "02a36b785d584555696b69d1b2bbeff4010332b301e3edd316d79438554cacb3e7"
+	amounts := map[string]float64{
+		addr: float64(amt) / 1e8,
+	}
+	err := wallet.c.Call(ctx, "sendfromtreasury", &res, key, amounts)
+	log.Debugf("TSpend generated: %s", res)
+	return res, err
+}
+
+func sendToMultisig(ctx context.Context, wallet *dcrwProc) (string, error) {
+	var res walletjson.SendToMultiSigResult
+	amount := float64(1)
+	pubkeys := []string{
+		"Sse143dKKXu6LQm5TNfpjcAYBbuuLQ3DKCj",
+		"SkQmYXQXBTJAvexVaQPixjW88St66zv5vN7DTUuuqpPJtC5fzMF37",
+	}
+	err := wallet.c.Call(ctx, "sendtomultisig", &res, "default", amount, pubkeys)
+	log.Debugf("Multisig tx generated: %s (addr %s)", res.TxHash, res.Address)
+
+	return res.TxHash, err
+}
+
+func redeemMultisig(ctx context.Context, wallet *dcrwProc, miner *dcrdProc, txh string) (string, error) {
+	var res walletjson.RedeemMultiSigOutResult
+	err := wallet.c.Call(ctx, "redeemmultisigout", &res, txh, 0, 0)
+	if err != nil {
+		return "", err
+	}
+
+	tx := &wire.MsgTx{}
+	bts, err := hex.DecodeString(res.Hex)
+	if err != nil {
+		return "", err
+	}
+	if err := tx.FromBytes(bts); err != nil {
+		return "", err
+	}
+	resHash, err := miner.c.SendRawTransaction(ctx, tx, true)
+	if err != nil {
+		return "", err
+	}
+	log.Debugf("Multisig redeem tx generated: %s", resHash)
+
+	return resHash.String(), err
+}
+
+func setTreasuryPolicy(ctx context.Context, wallet *dcrwProc) error {
+	key := "02a36b785d584555696b69d1b2bbeff4010332b301e3edd316d79438554cacb3e7"
+	return wallet.c.Call(ctx, "settreasurypolicy", nil, key, "yes")
+}
+
+func isMined(ctx context.Context, miner *dcrdProc, txh string) (bool, error) {
+	hash, err := chainhash.NewHashFromStr(txh)
+	if err != nil {
+		return false, err
+	}
+	tx, err := miner.c.GetRawTransactionVerbose(ctx, hash)
+	if err != nil {
+		return false, err
+	}
+	mined := tx.BlockHash != ""
+	log.Debugf("Mined %s at height %d (hash %s)", txh, tx.BlockHeight,
+		tx.BlockHash)
+	return mined, nil
+}
+
+func isTicketMissed(ctx context.Context, miner *dcrdProc, wallet *dcrwProc, ticket string, mine bool) error {
+	foundMissedTicket := false
+	for i := 0; !foundMissedTicket && i < int(chainParams.TicketExpiry); i++ {
+		missedTickets, err := miner.c.MissedTickets(ctx)
+		if err != nil {
+			return err
+		}
+		for _, txh := range missedTickets {
+			if txh.String() == ticket {
+				foundMissedTicket = true
+				break
+			}
+		}
+
+		if !mine {
+			break
+		}
+
+		if err := mineAndSyncWallet(ctx, miner, wallet, 10); err != nil {
+			return err
+		}
+	}
+
+	if !foundMissedTicket {
+		return fmt.Errorf("ticket %s was not missed", ticket)
+	}
+	return nil
+}
+
+func addrAndAmountFromTx(tx *wire.MsgTx, out int) (string, dcrutil.Amount, error) {
+	txout := tx.TxOut[out]
+
+	_, addrs, _, err := txscript.ExtractPkScriptAddrs(0, txout.PkScript, chainParams, true)
+	if err != nil {
+		return "", 0, err
+	}
+
+	if len(addrs) != 1 {
+		return "", 0, fmt.Errorf("no addresses in the given pkscript")
+	}
+
+	return addrs[0].String(), dcrutil.Amount(txout.Value), nil
+}
+
+// addrAndAmountFromTxh fetches the specified transaction output (txh and
+// output index) and returns the address and amount.
+func addrAndAmountFromTxh(ctx context.Context, miner *dcrdProc, txh string, out int) (string, dcrutil.Amount, error) {
+	hash, err := chainhash.NewHashFromStr(txh)
+	if err != nil {
+		return "", 0, err
+	}
+	tx, err := miner.c.GetRawTransaction(ctx, hash)
+	if err != nil {
+		return "", 0, err
+	}
+
+	return addrAndAmountFromTx(tx.MsgTx(), out)
+}
+
+func mineAndSyncWallet(ctx context.Context, miner *dcrdProc, wallet *dcrwProc, nb uint32) error {
+	_, height, err := miner.c.GetBestBlock(ctx)
+	if err != nil {
+		return err
+	}
+
+	for i := uint32(0); i < nb; i++ {
+		now := time.Now()
+		if _, err := miner.mine(ctx, 1); err != nil {
+			return nil
+		}
+		height += 1
+
+		if err := wallet.waitSynced(ctx, miner); err != nil {
+			return err
+		}
+
+		var lenMempool int
+		for i := 0; i < 20; i++ {
+			mempool, err := miner.c.GetRawMempool(ctx, chainjson.GRMAll)
+			if err != nil {
+				return err
+			}
+			lenMempool = len(mempool)
+			if height < chainParams.StakeValidationHeight {
+				break
+			} else if lenMempool >= 5 {
+				break
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+
+		if i%10 == 0 {
+			if err := wallet.selfTransferMany(ctx, 15); err != nil {
+				return err
+			}
+			time.Sleep(200 * time.Millisecond)
+		}
+
+		pool, _ := miner.nbLiveTickets(ctx)
+		if pool < 200 {
+			log.Tracef("Purchasing more tickets due to small size (%d)", pool)
+			nbTickets := 15
+			_, err = wallet.c.PurchaseTicket(ctx, "default", 100e8, nil, nil, &nbTickets,
+				nil, nil, nil, nil, nil)
+			if err != nil {
+				return err
+			}
+		}
+
+		//utxos, _ := wallet.nbUtxos(ctx)
+		utxos := 0
+		log.Tracef("Took %s to mine and sync (height %d, mempool %d, utxos %d, live tickets %d)",
+			time.Since(now).Truncate(time.Millisecond),
+			height, lenMempool, utxos, pool)
+	}
+
+	return nil
+
+}
+
+// genTestChain generates a comprehensive simnet test chain to assert correct
+// behavior under check:data.
+func genTestChain(ctx context.Context, miner *dcrdProc, wallet *dcrwProc) error {
+
+	// Generate many utxos in the wallet.
+	if err := wallet.genManyUtxos(ctx, miner); err != nil {
+		return fmt.Errorf("unable to self-transfer many: %v", err)
+	}
+	log.Debugf("Generated utxos")
+
+	// Send coins to an address multiple times to be deeply confirmed.
+	err := wallet.sendToAddr(ctx, targetAddr, 1e8)
+	if err != nil {
+		return err
+	}
+	err = wallet.sendToAddr(ctx, targetAddr, 2e8)
+	if err != nil {
+		return err
+	}
+
+	// Purchase a ticket that will never vote, thus requiring a revocation.
+	tickets, err := wallet.c.PurchaseTicket(ctx, "default", 100e8, nil, nonVotingAddr, nil,
+		nil, nil, nil, nil, nil)
+	if err != nil {
+		return err
+	}
+	nonVotingTicketHash := tickets[0].String()
+
+	// Mine past SVH.
+	_, curHeight, err := miner.c.GetBestBlock(ctx)
+	if err != nil {
+		return err
+	}
+	nbBlocks := chainParams.StakeValidationHeight - curHeight + 8
+	log.Debugf("Mining %d blocks to pass SVH", nbBlocks)
+	if err := mineAndSyncWallet(ctx, miner, wallet, uint32(nbBlocks)); err != nil {
+		return err
+	}
+
+	// Generate a TAdd and TSpend and vote to approve the TSpend.
+	log.Debugf("Generating treasury transactions")
+	tspendKey := "PsUUktzTqNKDRudiz3F4Chh5CKqqmp5W3ckRDhwECbwrSuWZ9m5fk"
+	if err := wallet.importPrivKey(ctx, tspendKey); err != nil {
+		return err
+	}
+	if err := setTreasuryPolicy(ctx, wallet); err != nil {
+		return err
+	}
+	taddTxh, err := sendToTreasury(ctx, wallet, 5e8)
+	if err != nil {
+		return err
+	}
+	tspendTxh, err := sendFromTreasury(ctx, wallet, "Ssg3b2pAqa3zJGCk8skQdspvzgMzoHiH361", 3e8)
+	if err != nil {
+		return err
+	}
+
+	// Generate 2 P2SH multisig txs and spend one of them.
+	multisigTxh, err := sendToMultisig(ctx, wallet)
+	if err != nil {
+		return err
+	}
+	multisigTxh2, err := sendToMultisig(ctx, wallet)
+	if err != nil {
+		return err
+	}
+	multisigRedeemTxh, err := redeemMultisig(ctx, wallet, miner, multisigTxh)
+	if err != nil {
+		return err
+	}
+
+	// Mine to approve tspend.
+	log.Debugf("Mining to approve tspend")
+	if err := mineAndSyncWallet(ctx, miner, wallet, 48*3); err != nil {
+		return err
+	}
+	wallet.logSpendableUtxos(ctx)
+
+	// Ensure all test txs are mined so that future checks behave as
+	// expected.
+	if minedTspend, err := isMined(ctx, miner, tspendTxh); !minedTspend || err != nil {
+		return fmt.Errorf("tspend was not mined (err=%v)", err)
+	}
+	if minedTadd, err := isMined(ctx, miner, taddTxh); !minedTadd || err != nil {
+		return fmt.Errorf("tadd was not mined (err=%v)", err)
+	}
+	if mined, err := isMined(ctx, miner, nonVotingTicketHash); !mined || err != nil {
+		return fmt.Errorf("non-voting ticket was not mined (err=%v)", err)
+	}
+	if mined, err := isMined(ctx, miner, multisigTxh); !mined || err != nil {
+		return fmt.Errorf("multisig tx was not mined (err=%v)", err)
+	}
+	if mined, err := isMined(ctx, miner, multisigTxh2); !mined || err != nil {
+		return fmt.Errorf("multisig tx was not mined (err=%v)", err)
+	}
+	if mined, err := isMined(ctx, miner, multisigRedeemTxh); !mined || err != nil {
+		return fmt.Errorf("multisig redeem tx was not mined (err=%v)", err)
+	}
+
+	// Ensure non-voting ticket is missed.
+	if err := isTicketMissed(ctx, miner, wallet, nonVotingTicketHash, true); err != nil {
+		return err
+	}
+	log.Debugf("Ticket %s was missed", nonVotingTicketHash)
+
+	// Ensure there's at least one ticket in the last test block. We mine
+	// one block after sending this PurchaseTicket request in order to mine
+	// the split tx.
+	txhs, err := wallet.c.PurchaseTicket(ctx, "default", 100e8, nil, nil, nil,
+		nil, nil, nil, nil, nil)
+	if err != nil {
+		return err
+	}
+	log.Debugf("Last purchased ticket: %s", txhs[0])
+	time.Sleep(100 * time.Millisecond)
+	if _, err := miner.mine(ctx, 1); err != nil {
+		return err
+	}
+	if err := miner.waitTxInMempool(ctx, txhs[0].String()); err != nil {
+		return err
+	}
+
+	// Send more coins just before mining the last test block.
+	err = wallet.sendToAddr(ctx, targetAddr, 3e8)
+	if err != nil {
+		return err
+	}
+
+	// Revoke the ticket by importing the key and issuing a revoke.
+	if err := wallet.importPrivKey(ctx, nonVotingPrivKey); err != nil {
+		return err
+	}
+	if err := wallet.rescanWallet(ctx); err != nil {
+		return err
+	}
+	if err := wallet.c.RevokeTickets(ctx); err != nil {
+		return err
+	}
+
+	// Mine the last test block.
+	err = miner.c.RegenTemplate(ctx)
+	if err != nil {
+		return err
+	}
+	time.Sleep(100 * time.Millisecond)
+	if _, err := miner.mine(ctx, 1); err != nil {
+		return err
+	}
+	if err := isTicketMissed(ctx, miner, wallet, nonVotingTicketHash, false); err == nil {
+		return fmt.Errorf("ticket %s still listed as missed", nonVotingTicketHash)
+	}
+	log.Debugf("Revoked ticket %s", nonVotingTicketHash)
+
+	// Send coins that will remain in the mempool.
+	err = wallet.sendToAddr(ctx, targetAddr, 5e8)
+	if err != nil {
+		return err
+	}
+
+	_, curHeight, err = miner.c.GetBestBlock(ctx)
+	if err != nil {
+		return err
+	}
+	wallet.logSpendableUtxos(ctx)
+	log.Infof("Finished preparing test chain at height %d", curHeight)
+
+	return nil
+}
+
+// checkTestChain performs some spot checks in the online dcrros instance to
+// assert it correctly catpures details from the generated test chain.
+func checkTestChain(ctx context.Context, dcrros *dcrrosProc, miner *dcrdProc, wallet *dcrwProc) error {
+
+	// Ensure the target address has the expected balance.
+	wantBalance := dcrutil.Amount(6e8)
+	gotBalance, err := dcrros.addrBalance(ctx, targetAddr.String())
+	if err != nil {
+		return err
+	}
+	if gotBalance != wantBalance {
+		return fmt.Errorf("target addr does not have expected balance. "+
+			"want=%s got=%s", wantBalance, gotBalance)
+	}
+	log.Debugf("Balance for target addr is %s", gotBalance)
+
+	// Ensure the multisig address has the expected balance.
+	wantBalance = dcrutil.Amount(1e8)
+	gotBalance, err = dcrros.addrBalance(ctx, "ScbHxeQjnRmfZSW33B4DF3RGYCrsrMMdcaT")
+	if err != nil {
+		return err
+	}
+	if gotBalance != wantBalance {
+		return fmt.Errorf("multisig addr does not have expected balance. "+
+			"want=%s got=%s", wantBalance, gotBalance)
+	}
+	log.Debugf("Balance for multisig is %s", gotBalance)
+
+	// Ensure the tspend target address has the expected balance.
+	wantBalance = 3e8
+	gotBalance, err = dcrros.addrBalance(ctx, "Ssg3b2pAqa3zJGCk8skQdspvzgMzoHiH361")
+	if err != nil {
+		return err
+	}
+	if gotBalance != wantBalance {
+		return fmt.Errorf("tspend target addr does not have expected balance. "+
+			"want=%s got=%s", wantBalance, gotBalance)
+	}
+	log.Debugf("Balance for tspend target is %s", gotBalance)
+
+	// Ensure the treasury has the expected balance.
+	wantBalance, err = miner.treasuryBalance(ctx)
+	if err != nil {
+		return err
+	}
+	gotBalance, err = dcrros.addrBalance(ctx, types.TreasuryAccountAdddress)
+	if err != nil {
+		return err
+	}
+	if gotBalance != wantBalance {
+		return fmt.Errorf("unexpected treasury balance. want=%s got=%s",
+			wantBalance, gotBalance)
+	}
+	log.Debugf("Treasury balance is %s", gotBalance)
+
+	lastBlockHash, _, err := miner.c.GetBestBlock(ctx)
+	if err != nil {
+		return err
+	}
+	lastBlock, err := miner.c.GetBlock(ctx, lastBlockHash)
+	if err != nil {
+		return err
+	}
+
+	// Find the revocation tx in the block, then verify the balance for the
+	// account in dcrros matches the expected one.
+	foundRevocation := false
+	for _, tx := range lastBlock.STransactions {
+		if !stake.IsSSRtx(tx) {
+			continue
+		}
+
+		foundRevocation = true
+		var addr string
+		addr, wantBalance, err = addrAndAmountFromTx(tx, 0)
+		if err != nil {
+			return err
+		}
+
+		gotBalance, err = dcrros.addrBalance(ctx, addr)
+		if err != nil {
+			return err
+		}
+		if gotBalance != wantBalance {
+			return fmt.Errorf("unexpected revocation balance. want=%s got=%s",
+				wantBalance, gotBalance)
+		}
+		break
+	}
+	if !foundRevocation {
+		return fmt.Errorf("could not find revocation in last block")
+	}
+
+	// Ensure the balance for the ticket that was revoked is zeroed.
+	wantBalance = 0
+	gotBalance, err = dcrros.addrBalance(ctx, nonVotingAddr.String())
+	if err != nil {
+		return err
+	}
+	if gotBalance != wantBalance {
+		return fmt.Errorf("unexpected revoked ticket balance. want=%s got=%s",
+			wantBalance, gotBalance)
+	}
+
+	// Find a ticket purchased in the last block and verify its balance is
+	// correct.
+	foundTicket := false
+	for _, tx := range lastBlock.STransactions {
+		if !stake.IsSStx(tx) {
+			continue
+		}
+
+		foundTicket = true
+		var addr string
+		addr, wantBalance, err = addrAndAmountFromTx(tx, 0)
+		if err != nil {
+			return err
+		}
+
+		gotBalance, err = dcrros.addrBalance(ctx, addr)
+		if err != nil {
+			return err
+		}
+		if gotBalance != wantBalance {
+			return fmt.Errorf("unexpected ticket balance. want=%s got=%s",
+				wantBalance, gotBalance)
+		}
+
+		break
+	}
+	if !foundTicket {
+		return fmt.Errorf("could not find ticket in last block")
+	}
+
+	// Find a vote in the last block and verify its balance is correct.
+	foundVote := false
+	for _, tx := range lastBlock.STransactions {
+		if !stake.IsSSGen(tx, true) {
+			continue
+		}
+
+		foundVote = true
+		var addr string
+		addr, wantBalance, err = addrAndAmountFromTx(tx, 2)
+		if err != nil {
+			return err
+		}
+
+		gotBalance, err = dcrros.addrBalance(ctx, addr)
+		if err != nil {
+			return err
+		}
+		if gotBalance != wantBalance {
+			return fmt.Errorf("unexpected vote balance. want=%s got=%s",
+				wantBalance, gotBalance)
+		}
+
+		// Additionally, check that the balance for the vote's
+		// originating ticket is zero.
+		ticketHash := tx.TxIn[1].PreviousOutPoint.Hash.String()
+		addr, _, err = addrAndAmountFromTxh(ctx, miner, ticketHash, 0)
+		if err != nil {
+			return err
+		}
+		wantBalance = 0
+		gotBalance, err = dcrros.addrBalance(ctx, addr)
+		if err != nil {
+			return err
+		}
+		if gotBalance != wantBalance {
+			return fmt.Errorf("unexpected vote balance. want=%s got=%s",
+				wantBalance, gotBalance)
+		}
+
+		break
+	}
+	if !foundVote {
+		return fmt.Errorf("could not find vote in last block")
+	}
+
+	return nil
+}

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -28,7 +28,7 @@ ROOTPATHPATTERN=$(echo $ROOTPATH | sed 's/\\/\\\\/g' | sed 's/\//\\\//g')
 MODPATHS=$(go list -m all | grep "^$ROOTPATHPATTERN" | cut -d' ' -f1)
 for module in $MODPATHS; do
   echo "==> ${module}"
-  env CC=gcc go test -short -tags rpctest ${module}/...
+  env CC=gcc go test ${module}/...
 
   # check linters
   MODNAME=$(echo $module | sed -E -e "s/^$ROOTPATHPATTERN//" \

--- a/types/errors.go
+++ b/types/errors.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Decred developers
+// Copyright (c) 2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -110,7 +110,11 @@ var errorCodeMsgs = map[ErrorCode]string{
 //
 // NOTE: this is part of the standard Go error interface.
 func (err ErrorCode) Error() string {
-	return errorCodeMsgs[err]
+	s := "undefined error code"
+	if msg, ok := errorCodeMsgs[err]; ok {
+		s = msg
+	}
+	return s
 }
 
 // Is returns true if the target error is also an error code, an Error value
@@ -313,6 +317,20 @@ func RError(err error) *rtypes.Error {
 	}
 
 	return ErrUnknown.Msg(err.Error()).RError()
+}
+
+// RErrorAsError converts the given rosetta types.Error into a standard go
+// error.
+func RErrorAsError(rerr *rtypes.Error) error {
+	if rerr == nil {
+		return nil
+	}
+
+	return &Error{
+		code:      ErrorCode(rerr.Code),
+		msg:       rerr.Message,
+		retriable: rerr.Retriable,
+	}
 }
 
 // RosettaErrorIs returns true is the passed Rosetta error value corresponds to

--- a/types/errors_test.go
+++ b/types/errors_test.go
@@ -421,5 +421,53 @@ func TestRosettaErrorIs(t *testing.T) {
 			break
 		}
 	}
+}
+
+// TestRErrorAsError asserts the RErrorAsError function works as expected.
+func TestRErrorAsError(t *testing.T) {
+	tests := []struct {
+		name    string
+		rerr    *rtypes.Error
+		wantErr *Error
+	}{{
+		name:    "nil error",
+		rerr:    nil,
+		wantErr: nil,
+	}, {
+		name: "filled error",
+		rerr: &rtypes.Error{
+			Code:      0xff,
+			Message:   "fooo",
+			Retriable: true,
+		},
+		wantErr: &Error{
+			code:      0xff,
+			msg:       "fooo",
+			retriable: true,
+		},
+	}}
+
+	for _, tc := range tests {
+		tc := tc
+		ok := t.Run(tc.name, func(t *testing.T) {
+			err := RErrorAsError(tc.rerr)
+			if (tc.wantErr == nil) != (err == nil) {
+				t.Fatalf("unexpected error. want=%v got=%v",
+					tc.wantErr, err)
+			}
+			if tc.wantErr == nil {
+				return
+			}
+			gotErr := err.(*Error)
+			if !reflect.DeepEqual(gotErr, tc.wantErr) {
+				t.Fatalf("unexpected error. want=%#v got=#%v",
+					tc.wantErr, gotErr)
+			}
+		})
+
+		if !ok {
+			break
+		}
+	}
 
 }


### PR DESCRIPTION
This adds a full End-to-End test suite to assert correct dcrros behavior, including running the required `rosetta-cli` `check:data` and `check:construction` tests on a local simnet that exercises a large number of situations actually found on chain.

The first commits perform some preparatory work to enable running consistent run of the e2e tests.

The main commit adds a new internal package that can produce the e2etest binary: that binary runs appropriate simnet dcrd, dcrwallet and dcrros nodes, prepares a test chain then executes the `rosetta-cli` tests.

The Github Actions CI is modified to run the e2e tests for all available db types. A Dockerfile is also included to allow running the e2e tests following the Rosetta spec recommendations.