### PR TITLE
multi: Switch to stable v0.1.0 for dcrros

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,6 @@
 FROM golang:1.15-buster AS builder
 
 # Build dcrd and include dcrctl as well.
-#
-# TODO: Switch to the tagged 1.6.0 once that is released.
 RUN git clone https://github.com/decred/dcrd
 RUN (cd dcrd && git checkout release-v1.6.0)
 RUN (cd dcrd && go install .)
@@ -19,7 +17,7 @@ RUN git clone https://github.com/decred/dcrctl
 RUN (cd dcrctl && git checkout release-v1.6.0)
 RUN (cd dcrctl && go install .)
 RUN git clone https://github.com/decred/dcrros
-RUN (cd dcrros && git checkout ff6b2ac7d559ea8298743c8893ae831c28c1c569)
+RUN (cd dcrros && git checkout release-v0.1.0)
 RUN (cd dcrros && go install .)
 
 # Stage 2: Build the final image starting from a cleaner base.

--- a/docs/release-notes/release-notes-0.1.0.md
+++ b/docs/release-notes/release-notes-0.1.0.md
@@ -1,0 +1,35 @@
+# dcrros v0.1.0
+
+This is the first official release for dcrros. It is compatible with and embeds
+version [1.6.0](https://github.com/decred/decred-binaries/releases/tag/v1.6.0)
+of the core Decred software.
+
+While `dcrros` has an extensive suite of tests, please note this product hasn't
+seen wide deployment in production yet, therefore please exercise caution and
+perform further checks to ensure it's meeting technical requirements of any
+application.
+
+## Features
+
+This first release includes the following features:
+
+- Support of Rosetta Specification version [1.4.10](https://www.rosetta-api.org/versions.html)
+- Compatible with Decred core software version [1.6.0](https://github.com/decred/decred-binaries/releases/tag/v1.6.0)
+- Full support for the Data API (including historical balances)
+- Full support for the Construction API (including offline capabilities)
+- Ability for dcrros to run and control a dcrd instance
+- Docker deployment of the stable version
+- E2E test infrastructure, including running `rosetta-cli` checks
+
+## Running
+
+The recommended way of running `dcrros`, according to Rosetta specs, is through
+docker:
+
+```shell
+$ docker build --tag dcrros:stable https://raw.githubusercontent.com/decred/dcrros/v0.1.0/Dockerfile
+$ docker run --rm -p 9128:9128/tcp dcrros:stable
+```
+
+For additional information on configuration options when running `dcrros` via
+docker, please see the [Docker Options](/docs/docker.md) document.


### PR DESCRIPTION
This adds release notes for v0.1.0 of dcrros and switches the main production Dockerfile to use a tagged v0.1.0 for building dcrros.

Note that while dcrros is _not_ tagged, this Dockerfile won't build. Tagging will be done once the final version of this PR is merged.