### PR TITLE
version: Return to v0.1.0

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -27,7 +27,7 @@ const (
 // versioning 2.0.0 spec (https://semver.org/).
 const (
 	Major uint = 0
-	Minor uint = 2
+	Minor uint = 1
 	Patch uint = 0
 )
 


### PR DESCRIPTION
This is needed to ensure the tagged version has the correct internal
version number.