### PR TITLE
docs: Add v0.1.1 release notes

### DIFF
--- a/docs/release-notes/release-notes-0.1.1.md
+++ b/docs/release-notes/release-notes-0.1.1.md
@@ -1,0 +1,10 @@
+# dcrros v0.1.1
+
+This is patch release for dcrros. It updates the internal libraries and
+references to use the latest released version of Decred software, namely version
+1.6.2 for `dcrd`.
+
+It also updates the internal E2E test docker to use the latest release of the
+rosetta-cli tools, version 0.7.2.
+
+

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -37,7 +37,7 @@ var (
 	// '-ldflags "-X github.com/decred/dcrd/internal/version.PreRelease=foo"'
 	// if needed.  It MUST only contain characters from semanticAlphabet per
 	// the semantic versioning spec.
-	PreRelease = "pre"
+	PreRelease = ""
 
 	// BuildMetadata is defined as a variable so it can be overridden during the
 	// build process with:


### PR DESCRIPTION
Also, it removes the "-pre" prerelease metadata, given this commit will
be tagged as v0.1.1