### PR TITLE
version: Remove pre-release build info

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,13 +17,13 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: decred/dcrd
-          ref: release-v1.7.0
+          ref: release-v1.7.5
           path: dcrd
       - name: Checkout dcrwallet
         uses: actions/checkout@v2
         with:
           repository: decred/dcrwallet
-          ref: release-v1.7.0
+          ref: release-v1.7.5
           path: dcrwallet
       - name: Checkout rosetta-cli
         uses: actions/checkout@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,7 +21,9 @@ jobs:
           path: dcrros
 
       - name: Install Linters
-        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.0"
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.0
+          golangci-lint version
 
       - name: Build
         working-directory: dcrros
@@ -31,7 +33,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: decred/dcrd
-          ref: release-v1.7.0
+          ref: release-v1.7.5
           path: dcrd
 
       - name: Install dcrd

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -8,10 +8,10 @@ FROM golang:1.17-buster AS builder
 # Build the latest compatible dcrd and dcrctl. Comment the checkout lines to use
 # the latest master.
 RUN git clone https://github.com/decred/dcrd
-RUN (cd dcrd && git checkout release-v1.7.0)
+RUN (cd dcrd && git checkout release-v1.7.5)
 RUN (cd dcrd && go install .)
 RUN git clone https://github.com/decred/dcrctl
-RUN (cd dcrctl && git checkout release-v1.7.0)
+RUN (cd dcrctl && git checkout release-v1.7.5)
 RUN (cd dcrctl && go install .)
 
 # Build from the current dir.

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -13,9 +13,9 @@ FROM golang:1.17-buster AS builder
 # Versions for the bins are updated as required by the current master version
 # of dcrros.
 RUN git clone https://github.com/decred/dcrd
-RUN (cd dcrd && git checkout release-v1.7.0 && go install .)
+RUN (cd dcrd && git checkout release-v1.7.5 && go install .)
 RUN git clone https://github.com/decred/dcrwallet
-RUN (cd dcrwallet && git checkout release-v1.7.0 && go install .)
+RUN (cd dcrwallet && git checkout release-v1.7.5 && go install .)
 RUN git clone https://github.com/coinbase/rosetta-cli
 RUN (cd rosetta-cli && git checkout v0.7.2 && go install .)
 copy . dcrros

--- a/backend/svc_construction.go
+++ b/backend/svc_construction.go
@@ -47,12 +47,12 @@ var _ rserver.ConstructionAPIServicer = (*Server)(nil)
 // The following metadata are *REQUIRED*:
 //
 //   - version (js number): Script Version to generate the address for. Only
-//   version 0 is currently supported.
+//     version 0 is currently supported.
 //
 // The following metadata are *OPTIONAL*:
 //
 //   - algo (js string): Either "ecdsa" or "schnorr" for secp256k1 curve keys.
-//   If unspecified, version 0 scripts generate an ecdsa key.
+//     If unspecified, version 0 scripts generate an ecdsa key.
 //
 // NOTE: This is part of the ConstructionAPIServicer interface.
 func (s *Server) ConstructionDerive(ctx context.Context,
@@ -201,14 +201,14 @@ func (s *Server) ConstructionMetadata(ctx context.Context,
 //
 // The underlying binary format is as follow:
 //
-//     version byte | binary tx | nb of prevouts | prevouts
+//	version byte | binary tx | nb of prevouts | prevouts
 //
 // - [version byte]: 1 byte version
 // - [binary tx]: wire tx, serialized in the standard way
 // - [nb of prevouts]: varint with number of previous outpoits
 // - [prevouts]: variable list of prevouts. Each one is serialized as follows:
 //
-//     amount | version | pk script len | pkscript
+//	amount | version | pk script len | pkscript
 //
 // - [amount]: 8 byte uint64 amount
 // - [version]: 2 byte uint16 version

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	decred.org/dcrwallet/v2 v2.0.0
 	github.com/coinbase/rosetta-sdk-go v0.7.2
 	github.com/davecgh/go-spew v1.1.1
-	github.com/decred/dcrd v1.2.1-0.20220120180802-74a67dce2480
+	github.com/decred/dcrd v1.2.1-0.20221010183630-f886cda024a0
 	github.com/decred/dcrd/blockchain/stake/v4 v4.0.0
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.3
 	github.com/decred/dcrd/chaincfg/v3 v3.1.1

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,8 @@ github.com/dchest/siphash v1.2.2/go.mod h1:q+IRvb2gOSrUnYoPqHiyHXS0FOBBOdl6tONBl
 github.com/deckarep/golang-set v0.0.0-20180603214616-504e848d77ea/go.mod h1:93vsz/8Wt4joVM7c2AVqh+YRMiUSc14yDtF28KmMOgQ=
 github.com/decred/base58 v1.0.3 h1:KGZuh8d1WEMIrK0leQRM47W85KqCAdl2N+uagbctdDI=
 github.com/decred/base58 v1.0.3/go.mod h1:pXP9cXCfM2sFLb2viz2FNIdeMWmZDBKG3ZBYbiSM78E=
-github.com/decred/dcrd v1.2.1-0.20220120180802-74a67dce2480 h1:1FnkGBfvIepIDV5rSYztB9TBxBGsvFrYh2qqPEO8wr4=
-github.com/decred/dcrd v1.2.1-0.20220120180802-74a67dce2480/go.mod h1:hwdNXscHt9DzjNq2E5wgOc9GAb+vcoyc3VfVP+yaHwc=
+github.com/decred/dcrd v1.2.1-0.20221010183630-f886cda024a0 h1:uit/2Eqbvq2r0koBDdUV1aJqNnQCAZzvNlvaV7vfrlU=
+github.com/decred/dcrd v1.2.1-0.20221010183630-f886cda024a0/go.mod h1:qWQzw6wUh94pXN7mQQx0hCh73TjmHXSqU3ytgMC299w=
 github.com/decred/dcrd/addrmgr/v2 v2.0.0/go.mod h1:5g9jPzBSQotmSnPri4oc1n5VVgWzPLlXwbr6HGoUVrg=
 github.com/decred/dcrd/bech32 v1.1.2/go.mod h1:5Eng/MFsKR8KKDeSxGZdYpGs8CIKxiedcqYddVqQuj0=
 github.com/decred/dcrd/blockchain/stake/v4 v4.0.0 h1:PwoCjCTbRvDUZKKs6N2Haus8XcbVXCJ9iGVs8C9sKwQ=
@@ -124,6 +124,7 @@ github.com/decred/dcrd/blockchain/stake/v4 v4.0.0/go.mod h1:bOgG7YTbTOWQgtHLL2l1
 github.com/decred/dcrd/blockchain/standalone/v2 v2.1.0 h1:aXh7a+86p+H65MGy0QKu4Juf3/j+Y5koVSyVYFMdqP0=
 github.com/decred/dcrd/blockchain/standalone/v2 v2.1.0/go.mod h1:t2qaZ3hNnxHZ5kzVJDgW5sp47/8T5hYJt7SR+/JtRhI=
 github.com/decred/dcrd/blockchain/v4 v4.0.0/go.mod h1:i1FeTNN0LUEWBSMoI3riAFgfVE1X/7Seoz1aJ7YQGbk=
+github.com/decred/dcrd/blockchain/v4 v4.1.0/go.mod h1:i1FeTNN0LUEWBSMoI3riAFgfVE1X/7Seoz1aJ7YQGbk=
 github.com/decred/dcrd/certgen v1.1.1 h1:MYPG5jCysnbF4OiJ1++YumFEu2p/MsM/zxmmqC9mVFg=
 github.com/decred/dcrd/certgen v1.1.1/go.mod h1:ivkPLChfjdAgFh7ZQOtl6kJRqVkfrCq67dlq3AbZBQE=
 github.com/decred/dcrd/chaincfg/chainhash v1.0.2/go.mod h1:BpbrGgrPTr3YJYRN3Bm+D9NuaFd+zGyNeIKgrhCXK60=

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -37,7 +37,7 @@ var (
 	// '-ldflags "-X github.com/decred/dcrd/internal/version.PreRelease=foo"'
 	// if needed.  It MUST only contain characters from semanticAlphabet per
 	// the semantic versioning spec.
-	PreRelease = "pre"
+	PreRelease = ""
 
 	// BuildMetadata is defined as a variable so it can be overridden during the
 	// build process with:


### PR DESCRIPTION
Requires #27 

This removes the pre-release build metadata in preparation to tagging a final v0.2.0 version.