### PR TITLE
docker: Switch stable release to v0.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,13 @@ FROM golang:1.17-buster AS builder
 
 # Build dcrd and include dcrctl as well.
 RUN git clone https://github.com/decred/dcrd
-RUN (cd dcrd && git checkout release-v1.6.2)
+RUN (cd dcrd && git checkout release-v1.7.5)
 RUN (cd dcrd && go install .)
 RUN git clone https://github.com/decred/dcrctl
-RUN (cd dcrctl && git checkout release-v1.6.2)
+RUN (cd dcrctl && git checkout release-v1.7.5)
 RUN (cd dcrctl && go install .)
 RUN git clone https://github.com/decred/dcrros
-RUN (cd dcrros && git checkout release-v0.1.1)
+RUN (cd dcrros && git checkout release-v0.2.0)
 RUN (cd dcrros && go install .)
 
 # Stage 2: Build the final image starting from a cleaner base.


### PR DESCRIPTION
~Requires #29~
~Requires tagging v0.2.0~

This switches the stable version of the Dockerfile to use the recently tagged v0.2.0 release.